### PR TITLE
Update for hcl tags

### DIFF
--- a/queries/hcl/tags.scm
+++ b/queries/hcl/tags.scm
@@ -2,7 +2,8 @@
 (block
   (identifier) @type
   (string_lit) @name
-) @definition.block
+  (#eq? @type "resource")
+) @definition.resource
 
 ; Capture variables (variable "my_var")
 (block
@@ -17,12 +18,6 @@
   (string_lit) @name
   (#eq? @type "output")
 ) @definition.output
-
-; Capture locals (locals {})
-(block
-  (identifier) @type
-  (#eq? @type "locals")
-) @definition.locals
 
 ; Capture modules (module "my_module")
 (block
@@ -45,3 +40,18 @@
   (string_lit) @name
   (#eq? @block_type "data")
 ) @definition.data
+
+; Locals and generic identifier-only blocks
+(block
+  (identifier) @type
+  (#eq? @type "locals")
+) @definition.locals
+(block
+  (identifier) @type
+  (#eq? @type "terraform")
+) @definition.terraform
+
+; Fallback: any block with just an identifier
+(block
+  (identifier) @type
+) @definition.block


### PR DESCRIPTION
This pull request refactors and extends the tagging logic in the `queries/hcl/tags.scm` file to improve the handling of HCL block types. The changes include reordering and refining block definitions, reintroducing `locals` and `terraform` block types, and adding a fallback for generic blocks.

### Refinements to block type handling:

* Updated the `resource` block definition to replace the generic block capture for better specificity. (`[queries/hcl/tags.scmL5-R6](diffhunk://#diff-c49dc889037c2834bee19fb36e2db1389b11c22fd5f5c070a51652d4713f6da4L5-R6)`)

### Reintroduction of specific block types:

* Reintroduced the `locals` block type with updated positioning and logic for better clarity and organization. (`[queries/hcl/tags.scmR43-R57](diffhunk://#diff-c49dc889037c2834bee19fb36e2db1389b11c22fd5f5c070a51652d4713f6da4R43-R57)`)
* Added a new `terraform` block type to explicitly handle Terraform-specific blocks. (`[queries/hcl/tags.scmR43-R57](diffhunk://#diff-c49dc889037c2834bee19fb36e2db1389b11c22fd5f5c070a51652d4713f6da4R43-R57)`)

### Fallback for generic block handling:

* Introduced a fallback rule to capture any block with just an identifier as a generic block, ensuring no block is left uncaptured. (`[queries/hcl/tags.scmR43-R57](diffhunk://#diff-c49dc889037c2834bee19fb36e2db1389b11c22fd5f5c070a51652d4713f6da4R43-R57)`)

### Removal of outdated logic:

* Removed the old `locals` block capture logic, replacing it with the updated and more flexible version. (`[queries/hcl/tags.scmL21-L26](diffhunk://#diff-c49dc889037c2834bee19fb36e2db1389b11c22fd5f5c070a51652d4713f6da4L21-L26)`)