### PR TITLE
Fix some minor type errors and aux files

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,5 +1,5 @@
 import time
-from kit import Repo
+from kit.repository import Repository as Repo
 
 def main():
     import argparse

--- a/src/kit/docstring_indexer.py
+++ b/src/kit/docstring_indexer.py
@@ -189,7 +189,11 @@ class DocstringIndexer:
             os.makedirs(self.persist_dir, exist_ok=True)
             
         # Updated backend instantiation: explicitly pass path and a clearer collection_name
-        self.backend: VectorDBBackend = backend or ChromaDBBackend(path=self.persist_dir, collection_name="kit_docstring_index")
+        str_persist_dir = str(self.persist_dir)
+        self.backend: VectorDBBackend = backend or ChromaDBBackend(
+            persist_dir=str_persist_dir,
+            collection_name="kit_docstring_index"
+        )
 
     def build(self, force: bool = False, level: str = "symbol", file_extensions: Optional[List[str]] = None) -> None:
         """(Re)build the docstring index.

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -4,6 +4,7 @@ from .repo_mapper import RepoMapper
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor
 from .vector_searcher import VectorSearcher
+from .llm_context import ContextAssembler
 import os
 import tempfile
 import subprocess
@@ -97,7 +98,7 @@ class Repository:
         Returns:
             List[Dict[str, Any]]: A list of dictionaries representing the extracted symbols.
         """
-        return self.mapper.extract_symbols(file_path)
+        return self.mapper.extract_symbols(file_path)  # type: ignore[arg-type]
 
     def search_text(self, query: str, file_pattern: str = "*") -> List[Dict[str, Any]]:
         """
@@ -241,8 +242,6 @@ class Repository:
 
     def get_context_assembler(self) -> 'ContextAssembler':
         """Return a ContextAssembler bound to this repository."""
-        from .llm_context import ContextAssembler  # local import to keep dependencies light
-
         return ContextAssembler(self)
 
     def find_symbol_usages(self, symbol_name: str, symbol_type: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -21,12 +21,12 @@ import types
 # ---------------------------------------------------------
 if 'openai' not in sys.modules:
     openai_dummy = types.ModuleType('openai')
-    openai_dummy.OpenAI = MagicMock()
+    openai_dummy.OpenAI = MagicMock() # type: ignore[attr-defined]
     sys.modules['openai'] = openai_dummy
 
 if 'anthropic' not in sys.modules:
     anthropic_dummy = types.ModuleType('anthropic')
-    anthropic_dummy.Anthropic = MagicMock()
+    anthropic_dummy.Anthropic = MagicMock() # type: ignore[attr-defined]
     sys.modules['anthropic'] = anthropic_dummy
 
 if 'google' not in sys.modules:
@@ -35,10 +35,10 @@ if 'google' not in sys.modules:
 
 if 'google.generativeai' not in sys.modules:
     generativeai_dummy = types.ModuleType('generativeai')
-    generativeai_dummy.configure = MagicMock()
-    generativeai_dummy.GenerativeModel = MagicMock()
+    generativeai_dummy.configure = MagicMock() # type: ignore[attr-defined]
+    generativeai_dummy.GenerativeModel = MagicMock() # type: ignore[attr-defined]
     # Attach submodule to parent "google"
-    sys.modules['google'].generativeai = generativeai_dummy
+    sys.modules['google'].generativeai = generativeai_dummy # type: ignore[attr-defined]
     sys.modules['google.generativeai'] = generativeai_dummy
 
 # --- Fixtures ---


### PR DESCRIPTION
### Refactoring and Code Cleanup:
* Refactored import in `scripts/benchmark.py` to use `Repository` from `kit.repository` instead of `Repo` from `kit`. This improves clarity and consistency in import naming.
* Removed a local import of `ContextAssembler` in `src/kit/repository.py` and replaced it with a module-level import to reduce redundancy.

### Type Safety:
* Added `# type: ignore[arg-type]` to suppress type-checking errors in the `extract_symbols` method of `src/kit/repository.py`.
* Updated test mocks in `tests/test_summaries.py` with `# type: ignore[attr-defined]` to suppress type-checking errors for dynamically mocked attributes. [[1]](diffhunk://#diff-7768121fc3f54644a7ec21339f551a0794083643aaee772a20758807397ad375L24-R29) [[2]](diffhunk://#diff-7768121fc3f54644a7ec21339f551a0794083643aaee772a20758807397ad375L38-R41)

### Backend Configurability:
* Enhanced the `ChromaDBBackend` constructor in `src/kit/vector_searcher.py` to accept an optional `collection_name` parameter, improving flexibility for backend configurations.
* Modified the `add` method of `VectorDBBackend` to accept an optional `ids` parameter, allowing more granular control over vector database operations.

### Summarizer Configuration:
* Updated the `Summarizer` class in `src/kit/summaries.py` to directly store the provided LLM client and ensure the configuration defaults to `OpenAIConfig` if none is provided. This simplifies initialization and improves clarity.
* Added explicit type annotations for `config`, `repo`, and `llm_client` in the `Summarizer` class to enhance type safety.

### Minor Fixes:
* Updated backend instantiation in `src/kit/docstring_indexer.py` to use `persist_dir` as a string for compatibility.
* Added `# type: ignore[dict-item]` to suppress type-checking errors in the `add` method of `ChromaDBBackend` when deleting documents.