### PR TITLE
Support custom base_url for openrouter and others

### DIFF
--- a/docs/src/content/docs/core-concepts/code-summarization.mdx
+++ b/docs/src/content/docs/core-concepts/code-summarization.mdx
@@ -29,7 +29,9 @@ To use code summarization, you'll need an LLM provider configured. Currently, Op
     # For Google
     export GOOGLE_API_KEY="AIzaSy..."
     ```
-    You only need to set the key for the provider(s) you intend to use. If no specific configuration is provided to the `Summarizer` (see 'Configuration (Advanced)' below), `kit` defaults to using OpenAI via `OpenAIConfig()` which expects `OPENAI_API_KEY`.
+    You only need to set the key for the provider(s) you intend to use. If no specific configuration is provided to the `Summarizer` (see 'Configuration (Advanced)' below), `kit` defaults to using OpenAI via `OpenAIConfig()`, which expects `OPENAI_API_KEY`.
+
+    For `OpenAIConfig`, you can also customize parameters such as the `model`, `temperature`, or `base_url` (e.g., for connecting to services like OpenRouter). See the 'Configuration (Advanced)' section for detailed examples.
 
 ## Basic Usage: Summarizing Files
 
@@ -97,6 +99,29 @@ openai_summarizer = repo.get_summarizer(config=openai_custom_config)
 # Summarize using the custom OpenAI configuration
 openai_summary = openai_summarizer.summarize_file("src/utils_openai.py")
 print(f"OpenAI Summary:\n{openai_summary}")
+
+#### Using OpenAI-Compatible Endpoints (e.g., OpenRouter)
+
+The `OpenAIConfig` also supports a `base_url` parameter, allowing you to use any OpenAI-compatible API endpoint, such as [OpenRouter](https://openrouter.ai/). This is useful for accessing a wide variety of models through a single API key and endpoint.
+
+To use OpenRouter:
+1. Your `api_key` in `OpenAIConfig` should be your OpenRouter API key.
+2. Set the `base_url` to OpenRouter's API endpoint (e.g., `https://openrouter.ai/api/v1`).
+3. The `model` parameter should be the specific model string as recognized by OpenRouter (e.g., `meta-llama/llama-3.3-70b-instruct`).
+
+```python
+# Example for OpenRouter
+openrouter_config = OpenAIConfig(
+    api_key="YOUR_OPENROUTER_API_KEY", # Replace with your OpenRouter key
+    model="meta-llama/llama-3.3-70b-instruct", # Example model on OpenRouter
+    base_url="https://openrouter.ai/api/v1"
+)
+
+openrouter_summarizer = repo.get_summarizer(config=openrouter_config)
+# Now, calls to openrouter_summarizer will go to OpenRouter
+# summary_via_or = openrouter_summarizer.summarize_file("path/to/file.py")
+# print(f"Summary via OpenRouter:\n{summary_via_or}")
+```
 
 # --- Anthropic Example --- 
 # Define custom Anthropic configuration

--- a/docs/src/content/docs/core-concepts/code-summarization.mdx
+++ b/docs/src/content/docs/core-concepts/code-summarization.mdx
@@ -109,7 +109,7 @@ To use OpenRouter:
 2. Set the `base_url` to OpenRouter's API endpoint (e.g., `https://openrouter.ai/api/v1`).
 3. The `model` parameter should be the specific model string as recognized by OpenRouter (e.g., `meta-llama/llama-3.3-70b-instruct`).
 
-```python
+```
 # Example for OpenRouter
 openrouter_config = OpenAIConfig(
     api_key="YOUR_OPENROUTER_API_KEY", # Replace with your OpenRouter key
@@ -118,9 +118,6 @@ openrouter_config = OpenAIConfig(
 )
 
 openrouter_summarizer = repo.get_summarizer(config=openrouter_config)
-# Now, calls to openrouter_summarizer will go to OpenRouter
-# summary_via_or = openrouter_summarizer.summarize_file("path/to/file.py")
-# print(f"Summary via OpenRouter:\n{summary_via_or}")
 ```
 
 # --- Anthropic Example --- 
@@ -132,7 +129,7 @@ anthropic_config = AnthropicConfig(
 # Get summarizer with specific Anthropic config
 anthropic_summarizer = repo.get_summarizer(config=anthropic_config)
 anthropic_summary = anthropic_summarizer.summarize_file("src/utils_anthropic.py")
-print(f"Anthropic Summary:\n{anthropic_summary}")
+# print(f"Anthropic Summary:\n{anthropic_summary}")
 
 # --- Google Example --- 
 # Define custom Google configuration

--- a/src/kit/summaries.py
+++ b/src/kit/summaries.py
@@ -247,10 +247,10 @@ class Summarizer:
             if isinstance(self.config, OpenAIConfig):
                 try:
                     import openai
-                    client_params = {"api_key": self.config.api_key}
                     if self.config.base_url:
-                        client_params["base_url"] = self.config.base_url
-                    self._llm_client = openai.OpenAI(**client_params)
+                        self._llm_client = openai.OpenAI(api_key=self.config.api_key, base_url=self.config.base_url)
+                    else:
+                        self._llm_client = openai.OpenAI(api_key=self.config.api_key)
                 except ImportError:
                     raise LLMError("OpenAI SDK (openai) not available. Please install it.")
             elif isinstance(self.config, AnthropicConfig):
@@ -283,10 +283,10 @@ class Summarizer:
         try:
             if isinstance(self.config, OpenAIConfig):
                 from openai import OpenAI # Local import for OpenAI client
-                client_params = {"api_key": self.config.api_key}
                 if self.config.base_url:
-                    client_params["base_url"] = self.config.base_url
-                client = OpenAI(**client_params)
+                    client = OpenAI(api_key=self.config.api_key, base_url=self.config.base_url)
+                else:
+                    client = OpenAI(api_key=self.config.api_key)
             elif isinstance(self.config, AnthropicConfig):
                 from anthropic import Anthropic # Local import for Anthropic client
                 client = Anthropic(api_key=self.config.api_key)  # type: ignore # Different client type

--- a/src/kit/summaries.py
+++ b/src/kit/summaries.py
@@ -46,6 +46,7 @@ class OpenAIConfig:
     model: str = "gpt-4o"
     temperature: float = 0.7
     max_tokens: int = 1000  # Default max tokens for summary
+    base_url: Optional[str] = None
 
     def __post_init__(self):
         if not self.api_key:
@@ -246,7 +247,10 @@ class Summarizer:
             if isinstance(self.config, OpenAIConfig):
                 try:
                     import openai
-                    self._llm_client = openai.OpenAI(api_key=self.config.api_key)
+                    client_params = {"api_key": self.config.api_key}
+                    if self.config.base_url:
+                        client_params["base_url"] = self.config.base_url
+                    self._llm_client = openai.OpenAI(**client_params)
                 except ImportError:
                     raise LLMError("OpenAI SDK (openai) not available. Please install it.")
             elif isinstance(self.config, AnthropicConfig):
@@ -279,7 +283,10 @@ class Summarizer:
         try:
             if isinstance(self.config, OpenAIConfig):
                 from openai import OpenAI # Local import for OpenAI client
-                client = OpenAI(api_key=self.config.api_key)
+                client_params = {"api_key": self.config.api_key}
+                if self.config.base_url:
+                    client_params["base_url"] = self.config.base_url
+                client = OpenAI(**client_params)
             elif isinstance(self.config, AnthropicConfig):
                 from anthropic import Anthropic # Local import for Anthropic client
                 client = Anthropic(api_key=self.config.api_key)  # type: ignore # Different client type

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Should resolve https://github.com/cased/kit/issues/14.

* Added a `base_url` parameter to the `OpenAIConfig` class, allowing users to specify custom API endpoints for OpenAI-compatible services (e.g., OpenRouter).

* Updated the initialization logic in the `Summarizer` class to pass the `base_url` parameter when creating an OpenAI client. 