### PR TITLE
Allow callers of add_file() to sit limits on filesize, filetypes

### DIFF
--- a/docs/src/content/docs/tutorials/ai_pr_reviewer.mdx
+++ b/docs/src/content/docs/tutorials/ai_pr_reviewer.mdx
@@ -119,10 +119,25 @@ patch = PatchSet(diff)
 # Add the raw diff
 assembler.add_diff(diff)
 
-# Add full content of changed / added files
+# Add full content of changed / added files – with safety guards
+LOCK_FILES = {
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Cargo.lock",
+    "composer.lock",
+}
+
 for p_file in patch:
-    if not p_file.is_removed_file:
-        assembler.add_file(p_file.path)
+    if p_file.is_removed_file:
+        continue  # nothing to embed
+
+    assembler.add_file(
+        p_file.path,
+        max_lines=400,              # Inline only if the file is reasonably small
+        skip_if_name_in=LOCK_FILES, # Skip bulky lock files entirely (diff already added)
+    )
 
 # Semantic search for related code using PR title/description
 for q in filter(None, [pr_title, pr_description]):

--- a/src/kit/llm_context.py
+++ b/src/kit/llm_context.py
@@ -39,16 +39,31 @@ class ContextAssembler:
             return
         self._sections.append("## Diff\n```diff\n" + diff.strip() + "\n```")
 
-    def add_file(self, file_path: str, *, highlight_changes: bool = False) -> None:
+    def add_file(self, file_path: str, *, highlight_changes: bool = False,
+                 max_lines: int | None = None,
+                 max_bytes: int | None = None,
+                 skip_if_name_in: Optional[Sequence[str]] = None,
+                 ) -> None:
         """Embed full file content.
 
         If *highlight_changes* is true we still just inline raw content –
         markup is left to the caller/LLM.
         """
+        # Guard: skip by exact filename
+        if skip_if_name_in and Path(file_path).name in skip_if_name_in:
+            return
+
         try:
             code = self.repo.get_file_content(file_path)
         except FileNotFoundError:
             return
+
+        # Guards: size limits
+        if max_bytes is not None and len(code.encode("utf-8", "ignore")) > max_bytes:
+            return
+        if max_lines is not None and code.count("\n") + 1 > max_lines:
+            return
+
         lang = Path(file_path).suffix.lstrip(".") or "text"
         header = f"## {file_path} (full)" if not highlight_changes else f"## {file_path} (with changes highlighted)"
         self._sections.append(f"{header}\n```{lang}\n{code}\n```")

--- a/tests/test_context_assembler_limits.py
+++ b/tests/test_context_assembler_limits.py
@@ -1,0 +1,52 @@
+import pytest
+from pathlib import Path
+from kit import Repository
+
+
+def make_repo(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    return repo_root
+
+
+def test_skip_by_filename(tmp_path):
+    repo_root = make_repo(tmp_path)
+    (repo_root / "package-lock.json").write_text("{}\n")
+
+    repo = Repository(str(repo_root))
+    assembler = repo.get_context_assembler()
+
+    assembler.add_file(
+        "package-lock.json",
+        skip_if_name_in=["package-lock.json"],
+    )
+
+    ctx = assembler.format_context()
+    # lock file should be skipped -> context empty
+    assert "package-lock.json" not in ctx
+
+
+def test_skip_by_max_lines(tmp_path):
+    repo_root = make_repo(tmp_path)
+    big_file = repo_root / "big.py"
+    big_file.write_text("\n".join(["print('x')"] * 500))
+
+    repo = Repository(str(repo_root))
+    assembler = repo.get_context_assembler()
+
+    assembler.add_file("big.py", max_lines=100)
+    ctx = assembler.format_context()
+    assert "big.py" not in ctx
+
+
+def test_include_small_file(tmp_path):
+    repo_root = make_repo(tmp_path)
+    small = repo_root / "small.py"
+    small.write_text("print('hi')\n")
+
+    repo = Repository(str(repo_root))
+    assembler = repo.get_context_assembler()
+    assembler.add_file("small.py", max_lines=100)
+
+    ctx = assembler.format_context()
+    assert "small.py" in ctx 


### PR DESCRIPTION
Add extra context size safety for embedding file content in diffs. For now, set by callers, but in the future could have global settings, and/or pre-set configs.

* Add filename-based and size-based guards, modifying the `add_file` method to support these guards
* New tests to ensure correct behavior.
