### PR TITLE
Get full file tree in mcp

### DIFF
--- a/src/kit/mcp/server.py
+++ b/src/kit/mcp/server.py
@@ -448,9 +448,8 @@ class KitServerLogic:
                     return GetPromptResult(description="Symbol usages", messages=[PromptMessage(role="user", content=TextContent(type="text", text=json.dumps(usages, indent=2)))])
                 case "get_file_tree":
                     gft_args = GetFileTreeParams(**arguments)
-                    # Return URI reference instead of full JSON (avoid large payloads)
-                    self.get_file_tree(gft_args.repo_id)
-                    return GetPromptResult(description="File tree", messages=[PromptMessage(role="user", content=TextContent(type="text", text=f"/repos/{gft_args.repo_id}/tree"))])
+                    tree = self.get_file_tree(gft_args.repo_id)
+                    return GetPromptResult(description="File tree", messages=[PromptMessage(role="user", content=TextContent(type="text", text=json.dumps(tree, indent=2)))])
                 case "semantic_search":
                     ss_args = SemanticSearchParams(**arguments)
                     results = self.semantic_search(ss_args.repo_id, ss_args.query)
@@ -599,9 +598,8 @@ async def serve() -> None:
                 return [TextContent(type="text", text=json.dumps(usages, indent=2))]
             elif name == "get_file_tree":
                 gft_args = GetFileTreeParams(**arguments)
-                # Return URI reference instead of full JSON (avoid large payloads)
-                logic.get_file_tree(gft_args.repo_id)
-                return [TextContent(type="text", text=f"/repos/{gft_args.repo_id}/tree")]
+                tree = logic.get_file_tree(gft_args.repo_id)
+                return [TextContent(type="text", text=json.dumps(tree, indent=2))]
             elif name == "semantic_search":
                 ss_args = SemanticSearchParams(**arguments)
                 results = logic.semantic_search(ss_args.repo_id, ss_args.query)


### PR DESCRIPTION
This pull request updates the `get_file_tree` functionality to return full JSON payloads instead of URI references.

### Changes to `get_file_tree` functionality:
* Updated `get_prompt` and `call_tool` methods in `src/kit/mcp/server.py` to return the full JSON representation of the file tree instead of a URI reference. This change ensures that the file tree data is directly available in the response, formatted as a JSON string. [[1]](diffhunk://#diff-4f09806f531b312a0bd61c12c67429a626a54fecda0752c6904f0dde5d056b81L451-R452) [[2]](diffhunk://#diff-4f09806f531b312a0bd61c12c67429a626a54fecda0752c6904f0dde5d056b81L602-R602)

### Test coverage improvements:
* Added a new test case, `test_mcp_tool_output_get_file_tree`, in `tests/mcp/test_server.py` to validate the behavior of the `get_file_tree` functionality. This test ensures that the output is correctly formatted as a JSON string within `TextContent` and verifies the structure and content of the returned JSON.

### Minor adjustments:
* Updated imports in `tests/mcp/test_server.py` to include `json`, `TextContent`, and `GetFileTreeParams` to support the new test case.