### PR TITLE
No heading links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
         // Path to your custom CSS file, relative to the project root
         "./src/styles/theme.css",
       ],
+      markdown: { headingLinks: false },
       sidebar: [
         {
           label: " Introduction",

--- a/docs/src/content/docs/core-concepts/semantic-search.mdx
+++ b/docs/src/content/docs/core-concepts/semantic-search.mdx
@@ -3,7 +3,11 @@ title: Semantic Searching
 ---
 import { Aside } from '@astrojs/starlight/components';
 
-> **⚠ Experimental:** Vector / semantic search is an early feature.  APIs, CLI commands, and index formats may change in future releases without notice.
+<Aside type="caution" title="Experimental">
+  Vector / semantic search is an early feature.  APIs, CLI commands, and index formats may change in future releases without notice.
+</Aside>
+
+<br />
 
 kit supports semantic code search using vector embeddings and ChromaDB.
 
@@ -55,7 +59,7 @@ for hit in results:
 
 `vs.build_index(chunk_by="symbols")` (default) extracts functions/classes/variables via the existing AST parser.  This is usually what you want.
 
-* `chunk_by="lines"` splits code into ~50-line blocks – useful for languages where symbol extraction isn’t supported yet.
+* `chunk_by="lines"` splits code into ~50-line blocks – useful for languages where symbol extraction isn't supported yet.
 * You can re-index at any time; the previous collection is cleared automatically.
 
 ### Persisting & Re-using an Index

--- a/docs/src/content/docs/introduction/usage-guide.mdx
+++ b/docs/src/content/docs/introduction/usage-guide.mdx
@@ -108,6 +108,7 @@ context = repo.extract_context_around_line("src/my_module.py", line=42)
 
 ## Generating Code Summaries (Alpha)
 
+
 `kit` includes an alpha feature for generating natural language summaries (like dynamic docstrings) for code elements (files, functions, classes) using a configured Large Language Model (LLM). This can be useful for:
 
 *   Quickly understanding the purpose of a piece of code.


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `astro.config.mjs` file. The change disables heading links in markdown files by adding a `markdown: { headingLinks: false }` configuration option.

* [`docs/astro.config.mjs`](diffhunk://#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09fR23): Added `markdown: { headingLinks: false }` to disable automatic heading links in markdown files.