### PR TITLE
More flexibility in mcp and redis version range

### DIFF
--- a/docs/src/components/Card.astro
+++ b/docs/src/components/Card.astro
@@ -1,5 +1,4 @@
 ---
-// Card.astro – simple mintlify-like card.
 export interface Props {
   title: string;
   href?: string;

--- a/docs/src/components/CardGroup.astro
+++ b/docs/src/components/CardGroup.astro
@@ -1,5 +1,4 @@
 ---
-// CardGroup.astro – grid container for Card components.
 export interface Props { cols?: number }
 const { cols = 2 } = Astro.props;
 const grid = `repeat(${cols}, minmax(0, 1fr))`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "python-hcl2>=7.2.0",
     "mypy",
     "ruff",
-    "mcp==1.8.0"
+    "mcp>=1.8.0,<2.0.0",
+    "redis>=5.0.0,<6.0.0"
 ]
 
 [project.urls]

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script runs linting and formatting checks using Ruff.
+# Pass --fix as the first argument to automatically apply fixes.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Navigate to the root of the repository relative to the script directory
+cd "$(dirname "$0")/.."
+
+# Check the first argument
+if [ "$1" == "--fix" ]; then
+  echo "Running Ruff to apply fixes (linting and formatting)..."
+  # Apply lint rule fixes (autofixable ones)
+  ruff check . --fix
+  # Apply formatting fixes
+  ruff format .
+  echo "Ruff fixes applied successfully!"
+else
+  echo "Running Ruff linter and formatting check (no fixes applied)..."
+  # Ruff check combines linting and format checking
+  ruff check .
+  echo "Ruff checks passed successfully!"
+fi 

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -13,7 +13,6 @@ from .repo_mapper import RepoMapper
 from .repository import Repository
 from .tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
 
-# search helpers
 from .vector_searcher import VectorSearcher
 
 try:

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -12,7 +12,6 @@ from .llm_context import ContextAssembler
 from .repo_mapper import RepoMapper
 from .repository import Repository
 from .tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
-
 from .vector_searcher import VectorSearcher
 
 try:

--- a/src/kit/cli.py
+++ b/src/kit/cli.py
@@ -11,7 +11,7 @@ def serve(host: str = "0.0.0.0", port: int = 8000, reload: bool = True):
     try:
         import uvicorn
 
-        from kit.api import app as fastapi_app  # Import the FastAPI app instance
+        from kit.api import app as fastapi_app
     except ImportError:
         typer.secho(
             "Error: FastAPI or Uvicorn not installed. Please run `pip install kit[api]`",

--- a/src/kit/code_searcher.py
+++ b/src/kit/code_searcher.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import pathspec  # Added for .gitignore handling
+import pathspec
 
 
 @dataclass

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -1,13 +1,7 @@
 import logging
 import traceback
+from importlib.resources import files  # type: ignore[no-redef]
 from typing import Any, ClassVar, Dict, List, Optional, cast
-
-try:
-    # Python 3.9+
-    from importlib.resources import files  # type: ignore[no-redef]
-except ImportError:
-    # Fallback for Python 3.8 or below
-    from importlib_resources import files  # type: ignore[no-redef]
 
 from tree_sitter_language_pack import get_language, get_parser
 

--- a/src/kit/vector_searcher.py
+++ b/src/kit/vector_searcher.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional
 try:
     import chromadb
     from chromadb import PersistentClient
-    from chromadb.config import Settings
 except ImportError:
     chromadb = None  # type: ignore[assignment]
 

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233 },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -172,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -186,6 +195,7 @@ dependencies = [
     { name = "pathspec" },
     { name = "pytest" },
     { name = "python-hcl2" },
+    { name = "redis" },
     { name = "ruff" },
     { name = "sentence-transformers" },
     { name = "tiktoken" },
@@ -207,13 +217,14 @@ requires-dist = [
     { name = "chromadb", specifier = ">=0.5.23" },
     { name = "fastapi", specifier = ">=0.100" },
     { name = "google-genai", specifier = ">=1.14.0" },
-    { name = "mcp", specifier = "==1.8.0" },
+    { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "mypy" },
     { name = "numpy", specifier = ">=1.25" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pathspec", specifier = ">=0.11.1" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "python-hcl2", specifier = ">=7.2.0" },
+    { name = "redis", specifier = ">=5.0.0,<6.0.0" },
     { name = "ruff" },
     { name = "sentence-transformers", specifier = ">=2.2.0" },
     { name = "tiktoken", specifier = ">=0.4.0" },
@@ -1528,15 +1539,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/3c/c99b21646a782b89c33cffd96fdee02a81bc43f0cb651de84d58ec11e30e/onnxruntime-1.22.0-cp310-cp310-macosx_13_0_universal2.whl", hash = "sha256:85d8826cc8054e4d6bf07f779dc742a363c39094015bdad6a08b3c18cfe0ba8c", size = 34273493 },
     { url = "https://files.pythonhosted.org/packages/54/ab/fd9a3b5285008c060618be92e475337fcfbf8689787953d37273f7b52ab0/onnxruntime-1.22.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:468c9502a12f6f49ec335c2febd22fdceecc1e4cc96dfc27e419ba237dff5aff", size = 14445346 },
     { url = "https://files.pythonhosted.org/packages/1f/ca/a5625644bc079e04e3076a5ac1fb954d1e90309b8eb987a4f800732ffee6/onnxruntime-1.22.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:681fe356d853630a898ee05f01ddb95728c9a168c9460e8361d0a240c9b7cb97", size = 16392959 },
+    { url = "https://files.pythonhosted.org/packages/6d/6b/8267490476e8d4dd1883632c7e46a4634384c7ff1c35ae44edc8ab0bb7a9/onnxruntime-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:20bca6495d06925631e201f2b257cc37086752e8fe7b6c83a67c6509f4759bc9", size = 12689974 },
     { url = "https://files.pythonhosted.org/packages/7a/08/c008711d1b92ff1272f4fea0fbee57723171f161d42e5c680625535280af/onnxruntime-1.22.0-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:8d6725c5b9a681d8fe72f2960c191a96c256367887d076b08466f52b4e0991df", size = 34282151 },
     { url = "https://files.pythonhosted.org/packages/3e/8b/22989f6b59bc4ad1324f07a945c80b9ab825f0a581ad7a6064b93716d9b7/onnxruntime-1.22.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef17d665a917866d1f68f09edc98223b9a27e6cb167dec69da4c66484ad12fd", size = 14446302 },
     { url = "https://files.pythonhosted.org/packages/7a/d5/aa83d084d05bc8f6cf8b74b499c77431ffd6b7075c761ec48ec0c161a47f/onnxruntime-1.22.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b978aa63a9a22095479c38371a9b359d4c15173cbb164eaad5f2cd27d666aa65", size = 16393496 },
+    { url = "https://files.pythonhosted.org/packages/89/a5/1c6c10322201566015183b52ef011dfa932f5dd1b278de8d75c3b948411d/onnxruntime-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:03d3ef7fb11adf154149d6e767e21057e0e577b947dd3f66190b212528e1db31", size = 12691517 },
     { url = "https://files.pythonhosted.org/packages/4d/de/9162872c6e502e9ac8c99a98a8738b2fab408123d11de55022ac4f92562a/onnxruntime-1.22.0-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:f3c0380f53c1e72a41b3f4d6af2ccc01df2c17844072233442c3a7e74851ab97", size = 34298046 },
     { url = "https://files.pythonhosted.org/packages/03/79/36f910cd9fc96b444b0e728bba14607016079786adf032dae61f7c63b4aa/onnxruntime-1.22.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8601128eaef79b636152aea76ae6981b7c9fc81a618f584c15d78d42b310f1c", size = 14443220 },
     { url = "https://files.pythonhosted.org/packages/8c/60/16d219b8868cc8e8e51a68519873bdb9f5f24af080b62e917a13fff9989b/onnxruntime-1.22.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6964a975731afc19dc3418fad8d4e08c48920144ff590149429a5ebe0d15fb3c", size = 16406377 },
+    { url = "https://files.pythonhosted.org/packages/36/b4/3f1c71ce1d3d21078a6a74c5483bfa2b07e41a8d2b8fb1e9993e6a26d8d3/onnxruntime-1.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0d534a43d1264d1273c2d4f00a5a588fa98d21117a3345b7104fa0bbcaadb9a", size = 12692233 },
     { url = "https://files.pythonhosted.org/packages/a9/65/5cb5018d5b0b7cba820d2c4a1d1b02d40df538d49138ba36a509457e4df6/onnxruntime-1.22.0-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:fe7c051236aae16d8e2e9ffbfc1e115a0cc2450e873a9c4cb75c0cc96c1dae07", size = 34298715 },
     { url = "https://files.pythonhosted.org/packages/e1/89/1dfe1b368831d1256b90b95cb8d11da8ab769febd5c8833ec85ec1f79d21/onnxruntime-1.22.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a6bbed10bc5e770c04d422893d3045b81acbbadc9fb759a2cd1ca00993da919", size = 14443266 },
     { url = "https://files.pythonhosted.org/packages/1e/70/342514ade3a33ad9dd505dcee96ff1f0e7be6d0e6e9c911fe0f1505abf42/onnxruntime-1.22.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fe45ee3e756300fccfd8d61b91129a121d3d80e9d38e01f03ff1295badc32b8", size = 16406707 },
+    { url = "https://files.pythonhosted.org/packages/3e/89/2f64e250945fa87140fb917ba377d6d0e9122e029c8512f389a9b7f953f4/onnxruntime-1.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:5a31d84ef82b4b05d794a4ce8ba37b0d9deb768fd580e36e17b39e0b4840253b", size = 12691777 },
     { url = "https://files.pythonhosted.org/packages/9f/48/d61d5f1ed098161edd88c56cbac49207d7b7b149e613d2cd7e33176c63b3/onnxruntime-1.22.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a2ac5bd9205d831541db4e508e586e764a74f14efdd3f89af7fd20e1bf4a1ed", size = 14454003 },
     { url = "https://files.pythonhosted.org/packages/c3/16/873b955beda7bada5b0d798d3a601b2ff210e44ad5169f6d405b93892103/onnxruntime-1.22.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64845709f9e8a2809e8e009bc4c8f73b788cee9c6619b7d9930344eae4c9cd36", size = 16427482 },
 ]
@@ -2063,6 +2078,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344 },
+]
+
+[[package]]
 name = "pypika"
 version = "0.48.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2210,6 +2234,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310 },
+]
+
+[[package]]
+name = "redis"
+version = "5.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/dd/2b37032f4119dff2a2f9bbcaade03221b100ba26051bb96e275de3e5db7a/redis-5.3.0.tar.gz", hash = "sha256:8d69d2dde11a12dc85d0dbf5c45577a5af048e2456f7077d87ad35c1c81c310e", size = 4626288 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/b0/aa601efe12180ba492b02e270554877e68467e66bda5d73e51eaa8ecc78a/redis-5.3.0-py3-none-any.whl", hash = "sha256:f1deeca1ea2ef25c1e4e46b07f4ea1275140526b1feea4c6459c0ec27a10ef83", size = 272836 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces updates to dependencies and adds a new script for linting and formatting. The most notable changes include updating dependency constraints in `pyproject.toml` and adding a Bash script to streamline code quality checks using Ruff.

### Dependency Updates:
* Updated the `mcp` dependency to allow versions `>=1.8.0` but `<2.0.0`.
* Added a new `redis` dependency with version constraints `>=5.0.0` but `<6.0.0`.

### Tooling Enhancements:
* Added a new script `scripts/format.sh` to run Ruff for linting and formatting. The script supports an optional `--fix` argument to automatically apply fixes.