### PR TITLE
Fix empty dirs in local repo file tree

### DIFF
--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -66,6 +66,18 @@ def baz(): pass
                 "dir1/dir2/z.py",
             ],
         ),
+        (
+            {
+                ".gitignore": "dir1/a.py",
+                "dir1/a.py": "pass",
+                "dir2/b.py": "pass",
+            },
+            [
+                ".gitignore",
+                "dir2",
+                "dir2/b.py",
+            ],
+        ),
     ],
 )
 def test_repo_file_tree_various(structure, expected_treepaths):


### PR DESCRIPTION
Local repos with directories without any non-ignored files show up in file tree. This fixes it by only including directories with content.