### PR TITLE
LLM json schema + new docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
             "core-concepts/search-approaches",
             "core-concepts/code-summarization",
             "core-concepts/docstring-indexing",
+            "core-concepts/tool-calling-with-kit",
             "core-concepts/semantic-search",
             "core-concepts/configuring-semantic-search",
             "core-concepts/dependency-analysis",

--- a/docs/src/content/docs/core-concepts/tool-calling-with-kit.mdx
+++ b/docs/src/content/docs/core-concepts/tool-calling-with-kit.mdx
@@ -1,0 +1,193 @@
+---
+title: Tool-Calling with `kit`
+subtitle: Practical patterns for letting your LLM drive kit's code-intelligence APIs
+---
+
+Modern LLM runtimes (OpenAI *function-calling*, Anthropic *tools*, etc.) let you hand the model a **menu of functions** in JSON-Schema form.  The model then plans its own calls – no hard-coded if/else trees required.  With `kit` you can  expose its code-intelligence primitives (search, symbol extraction, summaries, etc) and let the LLM decide which one to execute in each turn.  Your app stays declarative: *"Here are the tools, here is the user's question, please help."*
+
+In practice that means you can drop `kit` into an existing chat agent with **zero orchestration logic** beyond registering the schema.  The rest of this guide shows the small amount of glue code needed and the conversational patterns that emerge.
+
+`kit` can expose its code-intelligence primitives as **callable tools**.  The lowest-friction way is via the built-in MCP server (`python -m kit.mcp`), but any runtime that can execute Python can surface the same JSON-schema to an LLM.  Once the schema is registered the model can decide _when_ to call:
+
+* `open_repository`
+* `search_code`
+* `extract_symbols`
+* `find_symbol_usages`
+* `get_file_tree`, `get_file_content`
+* `get_code_summary`
+
+This page shows the minimal JSON you need, the decision patterns the model will follow, and a multi-turn example.
+
+## 1  Register the tools
+
+### OpenAI Chat Completions
+
+```python
+from openai import OpenAI
+import json, asyncio, kit.mcp
+
+client = OpenAI()
+server = await kit.mcp.serve()      # or run as a subprocess
+
+functions = json.loads(server.create_initialization_options()["toolSchemaJson"])
+
+messages = [
+    {"role": "system", "content": "You are an AI software engineer. Feel free to call tools when you need context."},
+]
+```
+
+The `toolSchemaJson` blob would contain all current kit tools with JSON-Schema argument shapes.  Pass that list directly as the `tools` parameter to `client.chat.completions.create()`.
+
+### Anthropic (messages-v2)
+
+```python
+from anthropic import Anthropic
+anthropic = Anthropic()
+
+options = server.create_initialization_options()
+
+response = anthropic.messages.create(
+    model="claude-3-7-sonnet-20250219"
+    system="You are an AI software engineer…",
+    tools=options["tools"],
+    messages=[{"role": "user", "content": "I got a test failure around FooBar.  Help me."}],
+)
+```
+
+## 2  When should the model call which tool?
+
+Below is the heuristic kit's own prompts (and our internal dataset) encourage.  You **don't** need to hard-code this logic—the LLM will pick it up from the tool names / descriptions—but understanding the flow helps you craft better conversation instructions.
+
+| Situation | Suggested tool(s) |
+|-----------|-------------------|
+| No repo open yet | `open_repository` (first turn) |
+| "What files mention X?" | `search_code` (fast regex) |
+| "Show me the function/class definition" | `get_file_content` *or* `extract_symbols` |
+| "Where else is `my_func` used?" | 1) `extract_symbols` (file-level) → 2) `find_symbol_usages` |
+| "Summarize this file/function for the PR description" | `get_code_summary` |
+| IDE-like navigation | `get_file_tree` + `get_file_content` |
+
+A **typical multi-turn session**:
+
+```
+User: I keep getting KeyError("user_id") in prod.
+
+Assistant (tool call): search_code {"repo_id": "42", "query": "KeyError(\"user_id\")"}
+
+Tool result → 3 hits returned (files + line numbers)
+
+Assistant: The error originates in `auth/session.py` line 88.  Shall I show you that code?
+
+User: yes, show me.
+
+Assistant (tool call): get_file_content {"repo_id": "42", "file_path": "auth/session.py"}
+
+Tool result → file text
+
+Assistant: Here is the snippet … (explanatory text)
+```
+
+## 3  Prompt orchestration: system / developer messages
+
+Tool-calling conversations have **three channels of intent**:
+
+1. **System prompt** – your immutable instructions (e.g. *"You are an AI software-engineer agent."*)  
+2. **Developer prompt** – _app-level_ steering: *"If the user asks for code you have not seen, call `get_file_content` first."*  
+3. **User prompt** – the human's actual message.
+
+`kit` does *not* impose a format—you simply include the JSON-schema from `server.create_initialization_options()` in your `tools` / `functions` field and add whatever system/developer guidance you choose.  A common pattern is:
+
+```python
+system = """You are an AI software-engineer.
+Feel free to call tools when they help you answer precisely.
+When showing code, prefer the smallest snippet that answers the question.
+"""
+
+developer = """Available repos are already open in the session.
+Call `search_code` before you attempt to answer questions like
+  *"Where is X defined?"* or *"Show references to Y"*.
+Use `get_code_summary` before writing long explanations of unfamiliar files.
+"""
+
+messages = [
+    {"role": "system", "content": system},
+    {"role": "system", "name": "dev-instructions", "content": developer},
+    {"role": "user", "content": user_query},
+]
+```
+
+Because the developer message is separate from the user's content it can be updated dynamically by your app (e.g. after each tool result) without contaminating the visible chat transcript.
+
+## 4  Streaming multi-tool conversations
+
+Nothing prevents the LLM from chaining calls:
+
+1. `extract_symbols` on the failing file.
+2. Pick the function, then `get_code_summary` for a concise explanation.
+
+Frameworks like **LangChain**, **LlamaIndex** or **CrewAI** can route these calls automatically when you surface kit's MCP spec as their "tool" object.
+
+```python
+from langchain_community.tools import Tool
+kit_tools = [Tool.from_mcp_schema(t, call_kit_server) for t in options["tools"]]
+```
+
+## 5  Security considerations
+
+`get_file_content` streams raw code.  If you expose kit to an external service:
+
+* Restrict `open_repository` to a safe path.
+* Consider stripping secrets from returned text.
+* Disable `get_file_content` for un-trusted queries and rely on `extract_symbols` + `get_code_summary` instead.
+
+## 6  In-process (no extra server)
+
+If your application is **already written in Python** you don't have to spawn the MCP server at all—just keep a `Repository` instance in memory and expose thin wrappers as tools/functions:
+
+```python
+from typing import TypedDict
+from kit import Repository
+
+repo = Repository("/path/to/repo")
+
+class SearchArgs(TypedDict):
+    query: str
+    pattern: str
+
+def search_code(args: SearchArgs):
+    return repo.search_text(args["query"], file_pattern=args.get("pattern", "*.py"))
+```
+
+Then register the wrapper with your tool-calling framework:
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+functions = [
+    {
+        "name": "search_code",
+        "description": "Regex search across the active repository",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "pattern": {"type": "string", "default": "*.py"},
+            },
+            "required": ["query"],
+        },
+    },
+]
+
+client.chat.completions.create(
+    model="gpt-4o",
+    tools=functions,
+    messages=[...]
+)
+```
+
+Because everything stays in the same process you avoid IPC/JSON overhead and can share caches (e.g. the `RepoMapper` symbol index) across calls.
+
+**Tip:** if you later need multi-language tooling or a separate sandbox you can swap the wrapper for the MCP server without touching your prompt logic—the function schema stays the same.
+
+--- 

--- a/docs/src/content/docs/core-concepts/tool-calling-with-kit.mdx
+++ b/docs/src/content/docs/core-concepts/tool-calling-with-kit.mdx
@@ -7,7 +7,7 @@ Modern LLM runtimes (OpenAI *function-calling*, Anthropic *tools*, etc.) let you
 
 In practice that means you can drop `kit` into an existing chat agent with **zero orchestration logic** beyond registering the schema.  The rest of this guide shows the small amount of glue code needed and the conversational patterns that emerge.
 
-`kit` can expose its code-intelligence primitives as **callable tools**.  The lowest-friction way is via the built-in MCP server (`python -m kit.mcp`), but any runtime that can execute Python can surface the same JSON-schema to an LLM.  Once the schema is registered the model can decide _when_ to call:
+`kit` exposes its code-intelligence primitives as **callable tools**.  Inside Python you can grab the JSON-Schema list with a single helper (`kit.get_tool_schemas()`) and hand that straight to your LLM runtime.  Once the schema is registered the model can decide _when_ to call:
 
 * `open_repository`
 * `search_code`
@@ -24,19 +24,19 @@ This page shows the minimal JSON you need, the decision patterns the model will 
 
 ```python
 from openai import OpenAI
-import json, asyncio, kit.mcp
+from kit import get_tool_schemas
 
 client = OpenAI()
-server = await kit.mcp.serve()      # or run as a subprocess
 
-functions = json.loads(server.create_initialization_options()["toolSchemaJson"])
+# JSON-Schema for every kit tool
+functions = get_tool_schemas()
 
 messages = [
-    {"role": "system", "content": "You are an AI software engineer. Feel free to call tools when you need context."},
+    {"role": "system", "content": "You are an AI software engineer, some refer to as the 'Scottie Scheffler of Programming'. Feel free to call tools when you need context."},
 ]
 ```
 
-The `toolSchemaJson` blob would contain all current kit tools with JSON-Schema argument shapes.  Pass that list directly as the `tools` parameter to `client.chat.completions.create()`.
+`functions` is a list of JSON-Schema objects. Pass it directly as the `tools`/`functions` parameter to `client.chat.completions.create()`.
 
 ### Anthropic (messages-v2)
 
@@ -44,12 +44,13 @@ The `toolSchemaJson` blob would contain all current kit tools with JSON-Schema a
 from anthropic import Anthropic
 anthropic = Anthropic()
 
-options = server.create_initialization_options()
+# JSON-Schema for every kit tool
+functions = get_tool_schemas()
 
 response = anthropic.messages.create(
-    model="claude-3-7-sonnet-20250219"
+    model="claude-3-7-sonnet-20250219",
     system="You are an AI software engineer…",
-    tools=options["tools"],
+    tools=functions,
     messages=[{"role": "user", "content": "I got a test failure around FooBar.  Help me."}],
 )
 ```
@@ -95,7 +96,7 @@ Tool-calling conversations have **three channels of intent**:
 2. **Developer prompt** – _app-level_ steering: *"If the user asks for code you have not seen, call `get_file_content` first."*  
 3. **User prompt** – the human's actual message.
 
-`kit` does *not* impose a format—you simply include the JSON-schema from `server.create_initialization_options()` in your `tools` / `functions` field and add whatever system/developer guidance you choose.  A common pattern is:
+`kit` does *not* impose a format—you simply include the JSON-schema from `kit.get_tool_schemas()` in your `tools` / `functions` field and add whatever system/developer guidance you choose.  A common pattern is:
 
 ```python
 system = """You are an AI software-engineer.
@@ -125,11 +126,11 @@ Nothing prevents the LLM from chaining calls:
 1. `extract_symbols` on the failing file.
 2. Pick the function, then `get_code_summary` for a concise explanation.
 
-Frameworks like **LangChain**, **LlamaIndex** or **CrewAI** can route these calls automatically when you surface kit's MCP spec as their "tool" object.
+Frameworks like **LangChain**, **LlamaIndex** or **CrewAI** can route these calls automatically when you surface kit's tool schema as their "tool" object.
 
 ```python
 from langchain_community.tools import Tool
-kit_tools = [Tool.from_mcp_schema(t, call_kit_server) for t in options["tools"]]
+kit_tools = [Tool.from_mcp_schema(t, call_kit_server) for t in functions]
 ```
 
 ## 5  Security considerations
@@ -142,7 +143,7 @@ kit_tools = [Tool.from_mcp_schema(t, call_kit_server) for t in options["tools"]]
 
 ## 6  In-process (no extra server)
 
-If your application is **already written in Python** you don't have to spawn the MCP server at all—just keep a `Repository` instance in memory and expose thin wrappers as tools/functions:
+If your application is **already written in Python** you don't have to spawn any servers at all—just keep a `Repository` instance in memory and expose thin wrappers as tools/functions:
 
 ```python
 from typing import TypedDict
@@ -188,6 +189,6 @@ client.chat.completions.create(
 
 Because everything stays in the same process you avoid IPC/JSON overhead and can share caches (e.g. the `RepoMapper` symbol index) across calls.
 
-**Tip:** if you later need multi-language tooling or a separate sandbox you can swap the wrapper for the MCP server without touching your prompt logic—the function schema stays the same.
+**Tip:** if you later need multi-language tooling or a separate sandbox you can still swap in the MCP server without touching your prompt logic—the function schema stays the same.
 
---- 
+---

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -21,6 +21,9 @@ except ImportError:
     # Users will get an ImportError later if they try to use Summarizer.
     pass
 
+# Helper for LLM tool schemas
+from .tool_schemas import get_tool_schemas
+
 __all__ = [
     "Repository",
     "RepoMapper",
@@ -32,6 +35,7 @@ __all__ = [
     "ContextAssembler",
     "DependencyAnalyzer",
     "TreeSitterSymbolExtractor",
+    "get_tool_schemas",
     # Conditionally add Summarizer related classes if they were imported
     *(["Summarizer", "OpenAIConfig", "LLMError"] if "Summarizer" in globals() else []),
 ]

--- a/src/kit/tool_schemas.py
+++ b/src/kit/tool_schemas.py
@@ -4,9 +4,10 @@ This module lets you grab the same JSON-Schema objects that the MCP server
 would advertise, without having to spin up a server.  Pass the list directly
 as the `tools` / `functions` parameter to OpenAI, Anthropic, etc.
 """
+
 from __future__ import annotations
 
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 # Avoid importing heavy MCP dependencies at module-import time to prevent
 # unnecessary ImportError for users who never need the helper.  Everything is
@@ -29,8 +30,9 @@ def get_tool_schemas() -> List[Dict[str, Any]]:
     """
     # Late imports to avoid circular dependencies *and* to keep MCP optional
     try:
-        from kit.mcp.server import KitServerLogic  # type: ignore
         from mcp.types import Tool  # type: ignore
+
+        from kit.mcp.server import KitServerLogic  # type: ignore
     except ImportError as e:  # pragma: no cover – pack not installed
         raise ImportError(
             "`get_tool_schemas()` requires the optional `mcp` package. \n"
@@ -40,4 +42,4 @@ def get_tool_schemas() -> List[Dict[str, Any]]:
     logic = KitServerLogic()
     tools: List[Tool] = logic.list_tools()
     # `model_dump` is a Pydantic method (v2) that returns plain dicts ready for JSON
-    return [tool.model_dump(mode="json") for tool in tools] 
+    return [tool.model_dump(mode="json") for tool in tools]

--- a/src/kit/tool_schemas.py
+++ b/src/kit/tool_schemas.py
@@ -1,0 +1,43 @@
+"""Utility helpers for exposing kit's MCP tool schema to LLM runtimes.
+
+This module lets you grab the same JSON-Schema objects that the MCP server
+would advertise, without having to spin up a server.  Pass the list directly
+as the `tools` / `functions` parameter to OpenAI, Anthropic, etc.
+"""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+# Avoid importing heavy MCP dependencies at module-import time to prevent
+# unnecessary ImportError for users who never need the helper.  Everything is
+# imported lazily inside the function.
+
+__all__ = ["get_tool_schemas"]
+
+
+def get_tool_schemas() -> List[Dict[str, Any]]:
+    """Return the JSON-serialisable schema for every kit tool.
+
+    Example
+    -------
+    >>> from kit.tool_schemas import get_tool_schemas
+    >>> openai_client.chat.completions.create(
+    ...     model="gpt-4o",
+    ...     tools=get_tool_schemas(),
+    ...     messages=[...],
+    ... )
+    """
+    # Late imports to avoid circular dependencies *and* to keep MCP optional
+    try:
+        from kit.mcp.server import KitServerLogic  # type: ignore
+        from mcp.types import Tool  # type: ignore
+    except ImportError as e:  # pragma: no cover – pack not installed
+        raise ImportError(
+            "`get_tool_schemas()` requires the optional `mcp` package. \n"
+            "Install it via `pip install mcp-spec` or `pip install cased-kit[mcp]`."
+        ) from e
+
+    logic = KitServerLogic()
+    tools: List[Tool] = logic.list_tools()
+    # `model_dump` is a Pydantic method (v2) that returns plain dicts ready for JSON
+    return [tool.model_dump(mode="json") for tool in tools] 

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -16,4 +16,4 @@ def test_get_tool_schemas_basic():
     # Spot-check a few known tool names
     tool_names = {s["name"] for s in schemas}
     for expected in {"open_repository", "search_code", "get_file_tree", "get_file_content"}:
-        assert expected in tool_names, f"{expected} should be part of tool schema list" 
+        assert expected in tool_names, f"{expected} should be part of tool schema list"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,19 @@
+import kit
+
+
+def test_get_tool_schemas_basic():
+    """Ensure get_tool_schemas returns a non-empty list of JSON-serialisable dicts."""
+    schemas = kit.get_tool_schemas()
+
+    # Basic shape checks
+    assert isinstance(schemas, list) and schemas, "Expected non-empty list"
+    assert all(isinstance(s, dict) for s in schemas), "Every schema should be a dict"
+
+    # Required top-level keys from MCP Tool (name + inputSchema at minimum)
+    sample = schemas[0]
+    assert "name" in sample and "inputSchema" in sample, "Schema missing expected keys"
+
+    # Spot-check a few known tool names
+    tool_names = {s["name"] for s in schemas}
+    for expected in {"open_repository", "search_code", "get_file_tree", "get_file_content"}:
+        assert expected in tool_names, f"{expected} should be part of tool schema list" 


### PR DESCRIPTION
This pull request introduces a new feature for integrating `kit`'s code-intelligence tools with LLM runtimes via JSON-Schema-based tool-calling. It includes documentation, implementation, and testing for this feature, enabling developers to expose `kit`'s functionality as callable tools in AI-driven workflows. The most significant changes are grouped below:

### Documentation Enhancements:
* Added a new guide, `tool-calling-with-kit`, explaining how to integrate `kit`'s tools with LLM runtimes like OpenAI and Anthropic. The guide includes examples, conversational patterns, and security considerations (`docs/src/content/docs/core-concepts/tool-calling-with-kit.mdx`, [docs/src/content/docs/core-concepts/tool-calling-with-kit.mdxR1-R194](diffhunk://#diff-f81d9d84bfc7bd412f54ad858871913991fcdc8f981bc8d386b408fb91727d4cR1-R194)).
* Updated `astro.config.mjs` to include the new guide in the documentation navigation (`docs/astro.config.mjs`, [docs/astro.config.mjsR37](diffhunk://#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09fR37)).

### New Feature Implementation:
* Introduced a `get_tool_schemas` helper in `src/kit/tool_schemas.py` to provide JSON-Schema definitions for `kit` tools. This allows seamless integration with LLM runtimes without requiring an MCP server (`src/kit/tool_schemas.py`, [src/kit/tool_schemas.pyR1-R43](diffhunk://#diff-2b2d6fb5f71a46b87171139e4d446a6234cee87a4431f258748e4d09de3b0cadR1-R43)).
* Exported `get_tool_schemas` in `kit`'s public API by adding it to `__all__` in `src/kit/__init__.py` (`src/kit/__init__.py`, [[1]](diffhunk://#diff-c9131a50757fe4429bed833db95904d001bff1491ffbb4de4d552d9e8ee799a7R24-R26) [[2]](diffhunk://#diff-c9131a50757fe4429bed833db95904d001bff1491ffbb4de4d552d9e8ee799a7R38).

### Testing:
* Added a unit test, `test_get_tool_schemas_basic`, to validate the output of `get_tool_schemas`, ensuring it returns valid JSON-Schema definitions with expected tool names (`tests/test_tool_schemas.py`, [tests/test_tool_schemas.pyR1-R19](diffhunk://#diff-4a3bbefde5abc02d7f13c948f853667d46ff3c9a9153cb1e59af3ce923060d7eR1-R19)).