### PR TITLE
Better handling for tsx; test improvements

### DIFF
--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -17,7 +17,7 @@ LANGUAGES: dict[str, str] = {
     ".hcl": "hcl",
     ".tf": "hcl",
     ".ts": "typescript",
-    ".tsx": "typescript",
+    ".tsx": "tsx",
     ".c": "c",
     ".rb": "ruby",
     ".java": "java",
@@ -58,8 +58,15 @@ class TreeSitterSymbolExtractor:
         resource_package = f"kit.queries.{lang_name}"
         try:
             language = get_language(cast(Any, lang_name))  # type: ignore[arg-type]
+
+            # Prefer tags under the language's own directory (e.g., tsx/) but
+            # gracefully fall back to TypeScript's tags if none are found.
             package_files = files("kit.queries").joinpath(lang_name)
             tags_path = package_files.joinpath("tags.scm")
+
+            if not tags_path.exists() and lang_name == "tsx":
+                # Fallback to TypeScript query definitions – they work for most TSX constructs.
+                tags_path = files("kit.queries").joinpath("typescript").joinpath("tags.scm")
 
             tags_content = tags_path.read_text(encoding="utf-8")
             query = language.query(tags_content)

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -64,11 +64,15 @@ class TreeSitterSymbolExtractor:
             package_files = files("kit.queries").joinpath(lang_name)
             tags_path = package_files.joinpath("tags.scm")
 
-            if not tags_path.exists() and lang_name == "tsx":
-                # Fallback to TypeScript query definitions – they work for most TSX constructs.
-                tags_path = files("kit.queries").joinpath("typescript").joinpath("tags.scm")
-
-            tags_content = tags_path.read_text(encoding="utf-8")
+            try:
+                tags_content = tags_path.read_text(encoding="utf-8")
+            except (FileNotFoundError, OSError) as e:
+                if lang_name == "tsx":
+                    # Fallback to TypeScript query definitions – they work for most TSX constructs.
+                    tags_path = files("kit.queries").joinpath("typescript").joinpath("tags.scm")
+                    tags_content = tags_path.read_text(encoding="utf-8")
+                else:
+                    raise e
             query = language.query(tags_content)
             cls._queries[ext] = query
             logger.debug(f"get_query: Query loaded successfully for ext {ext}")

--- a/tests/test_symbol_extractor_additional.py
+++ b/tests/test_symbol_extractor_additional.py
@@ -33,7 +33,6 @@ def _write_tmp_and_extract(tmpdir: str, filename: str, content: str):
             "sample.tsx",
             """import React from 'react';\nfunction MyComponent() { return <div/>; }\nexport class Helper {}\n""",
             {"MyComponent", "Helper"},
-            marks=pytest.mark.skip(reason="TSX/TypeScript extraction is not working properly"),
         ),
         pytest.param(
             "sample.rs",

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
This pull request includes updates to improve path handling, enhance TSX support in the symbol extractor, and address test coverage. The most important changes focus on ensuring consistent path resolution, adding fallback logic for TSX query definitions, and enabling previously skipped tests.

### Path Handling Improvements:
* [`src/kit/repository.py`](diffhunk://#diff-e5a3524443081ef48daf5f31e3a267ab8c4fb1ded3cf200c4271cc232dba22a0L31-R32): Updated `__init__` to use `.absolute()` instead of `.resolve()` for the repository root to avoid following symlinks, and modified `get_abs_path` to call `.resolve()` after joining paths for stable, canonical file paths. [[1]](diffhunk://#diff-e5a3524443081ef48daf5f31e3a267ab8c4fb1ded3cf200c4271cc232dba22a0L31-R32) [[2]](diffhunk://#diff-e5a3524443081ef48daf5f31e3a267ab8c4fb1ded3cf200c4271cc232dba22a0L424-R431)

### TSX Support Enhancements:
* [`src/kit/tree_sitter_symbol_extractor.py`](diffhunk://#diff-41ad561ebefabc7ce2fdf12677e67366caa9ff2515de0178877559148af89bd8L20-R20): Corrected the mapping for `.tsx` files to use "tsx" instead of "typescript" and added fallback logic to use TypeScript query definitions when TSX-specific queries are unavailable. [[1]](diffhunk://#diff-41ad561ebefabc7ce2fdf12677e67366caa9ff2515de0178877559148af89bd8L20-R20) [[2]](diffhunk://#diff-41ad561ebefabc7ce2fdf12677e67366caa9ff2515de0178877559148af89bd8R61-R70)

### Test Coverage Updates:
* [`tests/test_symbol_extractor_additional.py`](diffhunk://#diff-ecb7e90891dfb299c30c770a31d6376b9879a01ccfa917b0340d80c824e45fe8L36): Re-enabled a previously skipped test for TSX/TypeScript extraction, reflecting the improved support for TSX in the symbol extractor.