### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/kit/cli.py
+++ b/src/kit/cli.py
@@ -9,19 +9,21 @@ import typer
 
 from . import __version__
 
+
 def version_callback(value: bool):
     if value:
         typer.echo(f"kit version {__version__}")
         raise typer.Exit()
 
+
 app = typer.Typer(help="A modular toolkit for LLM-powered codebase understanding.")
+
 
 @app.callback()
 def main(
     version: Optional[bool] = typer.Option(
-        None, "--version", callback=version_callback, is_eager=True,
-        help="Show version and exit."
-    )
+        None, "--version", callback=version_callback, is_eager=True, help="Show version and exit."
+    ),
 ):
     """A modular toolkit for LLM-powered codebase understanding."""
     pass

--- a/src/kit/cli.py
+++ b/src/kit/cli.py
@@ -7,7 +7,24 @@ from typing import Optional
 
 import typer
 
+from . import __version__
+
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"kit version {__version__}")
+        raise typer.Exit()
+
 app = typer.Typer(help="A modular toolkit for LLM-powered codebase understanding.")
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=version_callback, is_eager=True,
+        help="Show version and exit."
+    )
+):
+    """A modular toolkit for LLM-powered codebase understanding."""
+    pass
 
 
 @app.command()


### PR DESCRIPTION
## Summary
• Add `--version` flag to the kit CLI that displays the current version number
• Uses Typer's callback pattern to register a global option that shows version and exits

## Usage
```bash
kit --version
# Output: kit version 0.6.1
```

🤖 Generated with [Claude Code](https://claude.ai/code)