### PR TITLE
Better deepseek support

### DIFF
--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -123,6 +123,11 @@ class TestOllamaSummarizer:
     @patch("requests.Session")
     def test_ollama_function_summarization(self, mock_session, mock_repo):
         """Test function summarization with Ollama."""
+        # Setup mock repo to return function symbols
+        mock_repo.extract_symbols.return_value = [
+            {"name": "hello", "type": "FUNCTION", "code": "def hello():\n    print('Hello, World!')"}
+        ]
+
         # Setup mock response
         mock_session_instance = Mock()
         mock_response = Mock()


### PR DESCRIPTION
This pull request introduces functionality to strip "thinking tokens" from reasoning model responses, ensuring cleaner outputs for end users. The `_strip_thinking_tokens` function is implemented and integrated across multiple modules, along with extensive testing to verify its behavior.

### Functionality to strip thinking tokens:

* [`src/kit/pr_review/reviewer.py`](diffhunk://#diff-17c4bf59f9701f94ebeb5077313b5b5af3c8851f6b18b45c94afceb85e335ae9R372-R383): Added `_strip_thinking_tokens` function to remove reasoning model tokens (e.g., `<think>...</think>`). Integrated this function into the `generate` method to clean responses before usage tracking and return. [[1]](diffhunk://#diff-17c4bf59f9701f94ebeb5077313b5b5af3c8851f6b18b45c94afceb85e335ae9R372-R383) [[2]](diffhunk://#diff-17c4bf59f9701f94ebeb5077313b5b5af3c8851f6b18b45c94afceb85e335ae9R525-R556)

* [`src/kit/summaries.py`](diffhunk://#diff-022528751d72e6dc957c54217740b84d3ac21db855b863d91e711283ae478facR123-R154): Added `_strip_thinking_tokens` function to the summaries module. Integrated it into methods like `summarize_file`, `summarize_function`, and `summarize_class` to clean reasoning model responses before logging and returning summaries. [[1]](diffhunk://#diff-022528751d72e6dc957c54217740b84d3ac21db855b863d91e711283ae478facR123-R154) [[2]](diffhunk://#diff-022528751d72e6dc957c54217740b84d3ac21db855b863d91e711283ae478facL555-R592) [[3]](diffhunk://#diff-022528751d72e6dc957c54217740b84d3ac21db855b863d91e711283ae478facL718-R759) [[4]](diffhunk://#diff-022528751d72e6dc957c54217740b84d3ac21db855b863d91e711283ae478facL879-R924)

### Testing enhancements:

* [`tests/test_ollama_integration.py`](diffhunk://#diff-568e3edc15b874a73a6c22170a85d580aaf7a29e35e3fe61611c05bd0b2a578cL3-R25): Added integration tests for `_strip_thinking_tokens` to verify its behavior with various reasoning token patterns and ensure clean outputs. Introduced fixtures and mocked responses for comprehensive testing. [[1]](diffhunk://#diff-568e3edc15b874a73a6c22170a85d580aaf7a29e35e3fe61611c05bd0b2a578cL3-R25) [[2]](diffhunk://#diff-568e3edc15b874a73a6c22170a85d580aaf7a29e35e3fe61611c05bd0b2a578cR298-R469)

* [`tests/test_pr_review.py`](diffhunk://#diff-2db58835afcc6b849dc087bf9e12a4f546821fbc11b6e8fc1be5da2e318d26fbR567-R671): Added tests for `_strip_thinking_tokens` in the PR reviewer context, covering edge cases like empty inputs, multiple token patterns, and responses without thinking tokens.