### PR TITLE
Openrouter support when using AI PR Reviewer

### DIFF
--- a/src/kit/pr_review/README.md
+++ b/src/kit/pr_review/README.md
@@ -160,6 +160,30 @@ You need a GitHub token with appropriate permissions:
 2. Format: `sk-xxxxxxxxxxxxxxxxx`
 3. Set: `export KIT_OPENAI_TOKEN="your_key"`
 
+#### Custom OpenAI Compatible Providers
+
+Kit supports any OpenAI compatible API provider by setting a custom `api_base_url`. Popular options include:
+
+**Together AI** (Cost-effective, fast inference)
+```bash
+export KIT_OPENAI_TOKEN="your_together_api_key"
+```
+
+**OpenRouter** (Access to many models via one API)
+```bash  
+export KIT_OPENAI_TOKEN="your_openrouter_api_key"
+```
+
+**Groq** (Ultra-fast inference)
+```bash
+export KIT_OPENAI_TOKEN="your_groq_api_key"
+```
+
+**Local OpenAI API Server** (e.g., text-generation-webui, vLLM)
+```bash
+export KIT_OPENAI_TOKEN="not-used"  # Local servers often don't need API keys
+```
+
 ### 3. Configuration
 
 #### Quick Setup
@@ -203,6 +227,52 @@ custom_pricing:
     gpt-4o:
       input_per_million: 2.50  
       output_per_million: 10.00
+```
+
+#### Custom OpenAI Compatible Provider Examples
+
+**Together AI Configuration:**
+```yaml
+llm:
+  provider: openai
+  model: "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+  api_key: "your_together_api_key"
+  api_base_url: "https://api.together.xyz/v1"
+  max_tokens: 4000
+  temperature: 0.1
+```
+
+**OpenRouter Configuration:**
+```yaml
+llm:
+  provider: openai
+  model: "anthropic/claude-3.5-sonnet"
+  api_key: "your_openrouter_api_key" 
+  api_base_url: "https://openrouter.ai/api/v1"
+  max_tokens: 4000
+  temperature: 0.1
+```
+
+**Groq Configuration:**
+```yaml
+llm:
+  provider: openai
+  model: "llama-3.3-70b-versatile"
+  api_key: "your_groq_api_key"
+  api_base_url: "https://api.groq.com/openai/v1"
+  max_tokens: 4000
+  temperature: 0.1
+```
+
+**Local OpenAI API Server Configuration:**
+```yaml
+llm:
+  provider: openai
+  model: "local-model-name"
+  api_key: "not-used"  # Local servers often don't require API keys
+  api_base_url: "http://localhost:8000/v1"
+  max_tokens: 4000
+  temperature: 0.1
 ```
 
 ## 🔧 Usage Examples

--- a/src/kit/pr_review/agentic_reviewer.py
+++ b/src/kit/pr_review/agentic_reviewer.py
@@ -731,7 +731,14 @@ class AgenticPRReviewer:
             raise RuntimeError("openai package not installed. Run: pip install openai")
 
         if not self._llm_client:
-            self._llm_client = openai.OpenAI(api_key=self.config.llm.api_key)
+            # Support custom OpenAI compatible providers via api_base_url
+            if self.config.llm.api_base_url:
+                self._llm_client = openai.OpenAI(
+                    api_key=self.config.llm.api_key,
+                    base_url=self.config.llm.api_base_url
+                )
+            else:
+                self._llm_client = openai.OpenAI(api_key=self.config.llm.api_key)
 
         tools = [
             {

--- a/src/kit/pr_review/config.py
+++ b/src/kit/pr_review/config.py
@@ -28,11 +28,11 @@ class ReviewDepth(Enum):
 def _detect_provider_from_model(model_name: str) -> Optional[LLMProvider]:
     """Detect LLM provider from model name."""
     model_lower = model_name.lower()
-    
+
     # Strip common prefixes first
     prefixes_to_strip = [
         "vertex_ai/",
-        "openrouter/", 
+        "openrouter/",
         "together/",
         "groq/",
         "fireworks/",
@@ -41,7 +41,7 @@ def _detect_provider_from_model(model_name: str) -> Optional[LLMProvider]:
         "bedrock/",
         "azure/",
     ]
-    
+
     stripped_model = model_lower
     for prefix in prefixes_to_strip:
         if stripped_model.startswith(prefix):
@@ -319,7 +319,7 @@ class ReviewConfig:
 #   temperature: 0.1
 
 # Example OpenAI compatible provider configurations:
-# 
+#
 # Together AI (https://together.ai/):
 # llm:
 #   provider: openai

--- a/src/kit/pr_review/config.py
+++ b/src/kit/pr_review/config.py
@@ -28,15 +28,36 @@ class ReviewDepth(Enum):
 def _detect_provider_from_model(model_name: str) -> Optional[LLMProvider]:
     """Detect LLM provider from model name."""
     model_lower = model_name.lower()
+    
+    # Strip common prefixes first
+    prefixes_to_strip = [
+        "vertex_ai/",
+        "openrouter/", 
+        "together/",
+        "groq/",
+        "fireworks/",
+        "perplexity/",
+        "replicate/",
+        "bedrock/",
+        "azure/",
+    ]
+    
+    stripped_model = model_lower
+    for prefix in prefixes_to_strip:
+        if stripped_model.startswith(prefix):
+            stripped_model = stripped_model[len(prefix):]
+            break
 
     # OpenAI model patterns
-    openai_patterns = ["gpt-", "o1-", "text-davinci", "text-curie", "text-babbage", "text-ada"]
-    if any(pattern in model_lower for pattern in openai_patterns):
+    openai_patterns = [
+        "gpt-", "o1-", "text-davinci", "text-curie", "text-babbage", "text-ada"
+    ]
+    if any(pattern in stripped_model for pattern in openai_patterns):
         return LLMProvider.OPENAI
 
     # Anthropic model patterns
     anthropic_patterns = ["claude-", "haiku", "sonnet", "opus"]
-    if any(pattern in model_lower for pattern in anthropic_patterns):
+    if any(pattern in stripped_model for pattern in anthropic_patterns):
         return LLMProvider.ANTHROPIC
 
     # Ollama model patterns - popular models available in Ollama
@@ -60,7 +81,7 @@ def _detect_provider_from_model(model_name: str) -> Optional[LLMProvider]:
         "alpaca",
         "devstral",
     ]
-    if any(pattern in model_lower for pattern in ollama_patterns):
+    if any(pattern in stripped_model for pattern in ollama_patterns):
         return LLMProvider.OLLAMA
 
     return None
@@ -249,6 +270,10 @@ class ReviewConfig:
                 "api_key": "sk-your_api_key_here",
                 "max_tokens": 4000,
                 "temperature": 0.1,
+                # For custom OpenAI compatible providers (e.g., Together AI, OpenRouter, etc.)
+                # "api_base_url": "https://api.together.xyz/v1",  # Example: Together AI
+                # "api_base_url": "https://openrouter.ai/api/v1",  # Example: OpenRouter
+                # "api_base_url": "http://localhost:8000/v1",      # Example: Local OpenAI API server
             },
             "review": {
                 "max_files": 50,
@@ -291,6 +316,44 @@ class ReviewConfig:
 #   api_base_url: "http://localhost:11434"  # Default Ollama endpoint
 #   api_key: "ollama"  # Placeholder (Ollama doesn't use API keys)
 #   max_tokens: 2000
+#   temperature: 0.1
+
+# Example OpenAI compatible provider configurations:
+# 
+# Together AI (https://together.ai/):
+# llm:
+#   provider: openai
+#   model: "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+#   api_key: "your_together_api_key"
+#   api_base_url: "https://api.together.xyz/v1"
+#   max_tokens: 4000
+#   temperature: 0.1
+#
+# OpenRouter (https://openrouter.ai/):
+# llm:
+#   provider: openai
+#   model: "anthropic/claude-3.5-sonnet"
+#   api_key: "your_openrouter_api_key"
+#   api_base_url: "https://openrouter.ai/api/v1"
+#   max_tokens: 4000
+#   temperature: 0.1
+#
+# Local OpenAI API server (e.g., text-generation-webui, vLLM):
+# llm:
+#   provider: openai
+#   model: "local-model-name"
+#   api_key: "not-used"  # Local servers often don't require API keys
+#   api_base_url: "http://localhost:8000/v1"
+#   max_tokens: 4000
+#   temperature: 0.1
+#
+# Groq (https://groq.com/):
+# llm:
+#   provider: openai
+#   model: "llama-3.3-70b-versatile"
+#   api_key: "your_groq_api_key"
+#   api_base_url: "https://api.groq.com/openai/v1"
+#   max_tokens: 4000
 #   temperature: 0.1
 """
 

--- a/src/kit/pr_review/cost_tracker.py
+++ b/src/kit/pr_review/cost_tracker.py
@@ -197,7 +197,7 @@ class CostTracker:
     @classmethod
     def _strip_model_prefix(cls, model_name: str) -> str:
         """Strip provider prefixes from model names.
-        
+
         Examples:
         - vertex_ai/claude-sonnet-4-20250514 -> claude-sonnet-4-20250514
         - openrouter/meta-llama/llama-3.3-70b -> meta-llama/llama-3.3-70b
@@ -206,7 +206,7 @@ class CostTracker:
         # Common prefixes to strip
         prefixes_to_strip = [
             "vertex_ai/",
-            "openrouter/", 
+            "openrouter/",
             "together/",
             "groq/",
             "fireworks/",
@@ -215,33 +215,33 @@ class CostTracker:
             "bedrock/",
             "azure/",
         ]
-        
+
         for prefix in prefixes_to_strip:
             if model_name.startswith(prefix):
                 return model_name[len(prefix):]
-        
+
         return model_name
 
     @classmethod
     def is_valid_model(cls, model_name: str) -> bool:
         """Check if a model name is valid/supported.
-        
+
         Supports prefixed model names like 'vertex_ai/claude-sonnet-4-20250514'.
         """
         # Try exact match first
         if model_name in cls.get_all_model_names():
             return True
-            
+
         # Try with prefix stripped
         stripped_model = cls._strip_model_prefix(model_name)
         if stripped_model in cls.get_all_model_names():
             return True
-            
+
         # Special case for Ollama - any model is valid since it's local
         if ":" in model_name and not model_name.startswith("http"):
             # Looks like an Ollama model (e.g., "llama3:latest", "qwen2.5-coder:7b")
             return True
-            
+
         return False
 
     @classmethod
@@ -249,33 +249,33 @@ class CostTracker:
         """Get model suggestions for an invalid model name."""
         all_models = cls.get_all_model_names()
         suggestions = []
-        
+
         # Strip prefix for comparison
         stripped_invalid = cls._strip_model_prefix(invalid_model).lower()
-        
+
         # Check for models that start similarly or contain common parts
         for model in all_models:
             lower_model = model.lower()
             # Check if models start similarly
             starts_similar = (
-                lower_model.startswith(stripped_invalid[:4]) or 
+                lower_model.startswith(stripped_invalid[:4]) or
                 stripped_invalid.startswith(lower_model[:4])
             )
             # Check if any significant parts match
             parts_match = any(
-                part in lower_model 
-                for part in stripped_invalid.split('-')[:2] 
+                part in lower_model
+                for part in stripped_invalid.split('-')[:2]
                 if len(part) > 2
             )
-            
+
             if starts_similar or parts_match:
                 suggestions.append(model)
 
         # If no good matches, return a few popular ones
         if not suggestions:
             popular_models = [
-                "gpt-4.1-nano", 
-                "gpt-4o-mini", 
+                "gpt-4.1-nano",
+                "gpt-4o-mini",
                 "claude-3-5-sonnet-20241022"
             ]
             suggestions = popular_models

--- a/src/kit/pr_review/reviewer.py
+++ b/src/kit/pr_review/reviewer.py
@@ -338,9 +338,9 @@ class PRReviewer:
                 response
             )
             self.cost_tracker.track_llm_usage(
-                self.config.llm.provider, 
-                self.config.llm.model, 
-                input_tokens, 
+                self.config.llm.provider,
+                self.config.llm.model,
+                input_tokens,
                 output_tokens
             )
 

--- a/src/kit/pr_review/reviewer.py
+++ b/src/kit/pr_review/reviewer.py
@@ -61,7 +61,7 @@ class PRReviewer:
 
         # Parse GitHub URL
         # https://github.com/owner/repo/pull/123
-        url_pattern = r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"
+        url_pattern = r"https://(?:\w+\.)?github\.com/([^/]+)/([^/]+)/pull/(\d+)"
         match = re.match(url_pattern, pr_input)
 
         if not match:
@@ -309,10 +309,21 @@ class PRReviewer:
         try:
             import openai
         except ImportError:
-            raise RuntimeError("openai package not installed. Run: pip install openai")
+            raise RuntimeError(
+                "openai package not installed. Run: pip install openai"
+            )
 
         if not self._llm_client:
-            self._llm_client = openai.OpenAI(api_key=self.config.llm.api_key)
+            # Support custom OpenAI compatible providers via api_base_url
+            if self.config.llm.api_base_url:
+                self._llm_client = openai.OpenAI(
+                    api_key=self.config.llm.api_key,
+                    base_url=self.config.llm.api_base_url
+                )
+            else:
+                self._llm_client = openai.OpenAI(
+                    api_key=self.config.llm.api_key
+                )
 
         try:
             response = self._llm_client.chat.completions.create(
@@ -323,9 +334,14 @@ class PRReviewer:
             )
 
             # Track cost
-            input_tokens, output_tokens = self.cost_tracker.extract_openai_usage(response)
+            input_tokens, output_tokens = self.cost_tracker.extract_openai_usage(
+                response
+            )
             self.cost_tracker.track_llm_usage(
-                self.config.llm.provider, self.config.llm.model, input_tokens, output_tokens
+                self.config.llm.provider, 
+                self.config.llm.model, 
+                input_tokens, 
+                output_tokens
             )
 
             content = response.choices[0].message.content

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 
 from kit.pr_review.config import (
     GitHubConfig,
@@ -19,7 +20,6 @@ from kit.pr_review.validator import (
     ValidationResult,
     validate_review_quality,
 )
-import yaml
 
 
 def test_pr_url_parsing():
@@ -142,7 +142,7 @@ def test_model_prefix_detection():
     assert CostTracker._strip_model_prefix(
         "openrouter/meta-llama/llama-3.1-8b-instruct"
     ) == "meta-llama/llama-3.1-8b-instruct"
-    
+
     assert CostTracker._strip_model_prefix(
         "openrouter/anthropic/claude-3.5-sonnet"
     ) == "anthropic/claude-3.5-sonnet"
@@ -151,7 +151,7 @@ def test_model_prefix_detection():
     assert CostTracker._strip_model_prefix(
         "together/meta-llama/Llama-3-8b-chat-hf"
     ) == "meta-llama/Llama-3-8b-chat-hf"
-    
+
     assert CostTracker._strip_model_prefix(
         "together/mistralai/Mixtral-8x7B-Instruct-v0.1"
     ) == "mistralai/Mixtral-8x7B-Instruct-v0.1"
@@ -160,7 +160,7 @@ def test_model_prefix_detection():
     assert CostTracker._strip_model_prefix(
         "groq/llama3-8b-8192"
     ) == "llama3-8b-8192"
-    
+
     assert CostTracker._strip_model_prefix(
         "groq/mixtral-8x7b-32768"
     ) == "mixtral-8x7b-32768"
@@ -179,7 +179,7 @@ def test_model_prefix_detection():
     assert CostTracker._strip_model_prefix(
         "gpt-4o"
     ) == "gpt-4o"
-    
+
     assert CostTracker._strip_model_prefix(
         "claude-3-5-sonnet-20241022"
     ) == "claude-3-5-sonnet-20241022"
@@ -208,7 +208,7 @@ def test_cost_tracking_with_prefixed_models():
         1000,
         500
     )
-    
+
     # Should use GPT-4o pricing despite the prefix
     expected_cost = (1000 / 1_000_000) * 2.50 + (500 / 1_000_000) * 10.00
     assert abs(tracker.breakdown.llm_cost_usd - expected_cost) < 0.0001
@@ -226,7 +226,7 @@ def test_cost_tracking_with_prefixed_models():
             800,
             400
         )
-    
+
     # Should extract claude-3-5-sonnet-20241022 and use its pricing
     expected_cost = (800 / 1_000_000) * 3.00 + (400 / 1_000_000) * 15.00
     assert abs(tracker.breakdown.llm_cost_usd - expected_cost) < 0.0001
@@ -336,6 +336,7 @@ def test_pr_reviewer_with_prefixed_models():
 def test_cli_with_prefixed_models():
     """Test CLI handles prefixed model names correctly."""
     from typer.testing import CliRunner
+
     from kit.cli import app
 
     runner = CliRunner()
@@ -362,21 +363,21 @@ def test_complex_prefixed_model_names():
     # Test deeply nested model names
     complex_models = [
         (
-            "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct", 
+            "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct",
             "accounts/fireworks/models/llama-v3p1-8b-instruct"
         ),
         (
-            "replicate/meta/llama-2-70b-chat:13c3cdee13ee059ab779f0291d29054dab00a47dad8261375654de5540165fb0",  # noqa: E501
+            "replicate/meta/llama-2-70b-chat:13c3cdee13ee059ab779f0291d29054dab00a47dad8261375654de5540165fb0",
             "meta/llama-2-70b-chat:13c3cdee13ee059ab779f0291d29054dab00a47dad8261375654de5540165fb0"
         ),
         # This one won't be stripped because "provider" is not in prefixes_to_strip
         (
-            "provider/org/team/model/version/variant", 
+            "provider/org/team/model/version/variant",
             "provider/org/team/model/version/variant"
         ),
         # This one won't be stripped because "a" is not in prefixes_to_strip
         (
-            "a/b/c/d/e/f/g", 
+            "a/b/c/d/e/f/g",
             "a/b/c/d/e/f/g"
         ),
     ]
@@ -394,7 +395,7 @@ def test_provider_prefix_detection():
     # Test known provider prefixes that are actually in prefixes_to_strip
     known_providers = [
         "openrouter",
-        "together", 
+        "together",
         "groq",
         "fireworks",
         "replicate",
@@ -445,7 +446,7 @@ def test_cost_tracking_edge_cases_with_prefixes():
 
         # Should warn about unknown pricing
         mock_print.assert_called()
-        
+
         # Should use fallback pricing
         expected_cost = (1000 / 1_000_000) * 3.0 + (500 / 1_000_000) * 15.0
         assert abs(tracker.breakdown.llm_cost_usd - expected_cost) < 0.0001
@@ -647,7 +648,7 @@ def test_config_custom_openai_provider():
 
     try:
         config = ReviewConfig.from_file(config_path)
-        
+
         assert config.llm.provider == LLMProvider.OPENAI
         assert config.llm.api_key == "together_api_key"
         assert config.llm.api_base_url == "https://api.together.xyz/v1"

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -254,6 +254,40 @@ def test_config_openai_provider():
         assert config.llm.model == "gpt-4o"
 
 
+def test_config_custom_openai_provider():
+    """Test custom OpenAI compatible provider configuration."""
+    import tempfile
+    import yaml
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        config_data = {
+            "github": {"token": "github_token"},
+            "llm": {
+                "provider": "openai",
+                "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                "api_key": "together_api_key",
+                "api_base_url": "https://api.together.xyz/v1",
+                "max_tokens": 4000,
+                "temperature": 0.1,
+            }
+        }
+        yaml.dump(config_data, f)
+        config_path = f.name
+
+    try:
+        config = ReviewConfig.from_file(config_path)
+        
+        assert config.llm.provider == LLMProvider.OPENAI
+        assert config.llm.api_key == "together_api_key"
+        assert config.llm.api_base_url == "https://api.together.xyz/v1"
+        assert config.llm.model == "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        assert config.llm.max_tokens == 4000
+        assert config.llm.temperature == 0.1
+    finally:
+        import os
+        os.unlink(config_path)
+
+
 def test_config_missing_tokens():
     """Test configuration error when tokens are missing."""
     with patch.dict(os.environ, {}, clear=True):

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "0.6.1"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

Even though there is a [fixed issue](https://github.com/cased/kit/issues/14#issuecomment-2864779518) that allows custom `base_url` so to use openrouter (or similar) that seems not to be working for the AI PR Reviewer. 

This PR purpose is to introduce this feature such openrouter can be used, for example: `vertex_ai/ claude-sonnet-4-20250514`.

## Introduced changes

- Add model prefix detection for popular providers (openrouter, together, groq, etc.)
- Enhance cost tracking to handle prefixed model names accurately
- Add documentation for OpenAI-compatible providers like Together AI and OpenRouter
- Update tests to validate new provider detection functionality
