### PR TITLE
Fix: Use base repo instead of head repo when fetching PR diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ test_repo*
 # Test results and matrix testing artifacts
 test-results/
 *.json
+
+# Pycharm
+.idea/

--- a/src/kit/pr_review/reviewer.py
+++ b/src/kit/pr_review/reviewer.py
@@ -135,7 +135,7 @@ class PRReviewer:
         # Create kit Repository instance
         repo = Repository(repo_path)
 
-        owner, repo_name = pr_details["head"]["repo"]["owner"]["login"], pr_details["head"]["repo"]["name"]
+        owner, repo_name = pr_details["base"]["repo"]["owner"]["login"], pr_details["base"]["repo"]["name"]
         pr_number = pr_details["number"]
         try:
             pr_diff = self.get_pr_diff(owner, repo_name, pr_number)  # cached


### PR DESCRIPTION
**Issue:**
Currently, the code fetches the PR diff using the owner and repo from the PR's `head` repository. However, since the PR comes from a forked repository into my own repository, the GitHub API call should use the `base` repository owner and repo (which is my repository) because the access token is authorized for my repository and does not have access to others' forks. This causes a 404 error and fails to retrieve the diff properly.

**Fix:**
Change the logic to retrieve the owner and repo from `pr_details["base"]["repo"]` instead of `pr_details["head"]["repo"]` to ensure the API request is made with the correct repository information, allowing the diff to be fetched successfully.

**Why it matters:**
This fix ensures the PR review process can access the changed files without permission issues, improving the tool’s reliability and functionality.

**Example:**
PR URL: [https://github.com/redvelvets/review-test/pull/1](https://github.com/redvelvets/review-test/pull/1)
PR Author: lefeia
Repository Owner: redvelvets (myself)
Incorrect usage: `head.repo` → 404 error
Correct usage: `base.repo` → diff fetch succeeds

![image](https://github.com/user-attachments/assets/e04cf574-1cd1-4f9c-af68-de00c66d45a8)
