### PR TITLE
Custom tree-sitter queries & plugin system

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig({
             "core-concepts/dependency-analysis",
             "core-concepts/llm-context-best-practices",
             "core-concepts/context-assembly",
+            "core-concepts/plugin-system",
           ],
         },
         {

--- a/docs/src/content/docs/core-concepts/plugin-system.mdx
+++ b/docs/src/content/docs/core-concepts/plugin-system.mdx
@@ -1,4 +1,6 @@
-# TreeSitter Symbol Extractor Plugin System
+---
+title: Tree-sitter Plugin System
+---
 
 kit includes a plugin system that allows you to extend and customize symbol extraction for any programming language. This system enables you to:
 

--- a/docs/src/content/docs/core-concepts/plugin-system.mdx
+++ b/docs/src/content/docs/core-concepts/plugin-system.mdx
@@ -1,0 +1,496 @@
+# TreeSitter Symbol Extractor Plugin System
+
+kit includes a plugin system that allows you to extend and customize symbol extraction for any programming language. This system enables you to:
+
+- **Extend existing languages** with additional query patterns (e.g., detect FastAPI routes in Python)
+- **Register completely new languages** with custom parsers and queries
+- **Load multiple query files** per language for modular organization
+- **Use custom query directories** for team-specific or project-specific patterns
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [API Reference](#api-reference)
+- [Extending Existing Languages](#extending-existing-languages)
+- [Registering New Languages](#registering-new-languages)
+- [Real-World Examples](#real-world-examples)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## Quick Start
+
+### Extending Python for Custom Patterns
+
+```python
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+# Define a custom query for detecting test functions
+test_query = '''
+(function_definition
+  name: (identifier) @name
+  (#match? @name "^test_")
+) @definition.test_function
+'''
+
+# Save query to a file
+with open('test_patterns.scm', 'w') as f:
+    f.write(test_query)
+
+# Extend Python language
+TreeSitterSymbolExtractor.extend_language("python", "test_patterns.scm")
+
+# Extract symbols with new patterns
+code = '''
+def test_user_login():
+    pass
+
+def regular_function():
+    pass
+'''
+
+symbols = TreeSitterSymbolExtractor.extract_symbols(".py", code)
+for symbol in symbols:
+    print(f"{symbol['type']}: {symbol['name']}")
+# Output:
+# test_function: test_user_login
+# function: test_user_login  
+# function: regular_function
+```
+
+## API Reference
+
+### Core Methods
+
+#### `extend_language(language: str, query_file: str) -> None`
+
+Extend an existing language with additional query patterns.
+
+- **language**: Language name (e.g., 'python', 'javascript')
+- **query_file**: Path to .scm query file (absolute or relative to queries directory)
+
+#### `register_language(name: str, extensions: List[str], query_files: List[str], query_dirs: Optional[List[str]] = None) -> None`
+
+Register a completely new language.
+
+- **name**: Language name (should match tree-sitter-language-pack)
+- **extensions**: File extensions (e.g., ['.kt', '.kts'])
+- **query_files**: List of .scm query files to load
+- **query_dirs**: Optional custom directories to search for queries
+
+#### `list_supported_languages() -> Dict[str, List[str]]`
+
+Returns mapping of language names to their supported file extensions.
+
+#### `reset_plugins() -> None`
+
+Reset all custom languages and extensions. Useful for testing and cleanup.
+
+### Symbol Structure
+
+Extracted symbols have this structure:
+
+```python
+{
+    "name": "function_name",      # Symbol name
+    "type": "function",           # Symbol type (function, class, method, etc.)
+    "start_line": 0,             # Starting line number (0-indexed)
+    "end_line": 5,               # Ending line number (0-indexed)
+    "code": "def function_name():\n    pass",  # Full symbol code
+    "subtype": "optional"        # Optional subtype for specialized symbols
+}
+```
+
+## Extending Existing Languages
+
+### Python: FastAPI Routes
+
+Detect FastAPI route decorators:
+
+```python
+fastapi_query = '''
+; FastAPI route handlers
+(decorated_definition
+  (decorator_list
+    (decorator
+      (call
+        (attribute
+          object: (identifier) @app_name
+          attribute: (identifier) @http_method
+        )
+        arguments: (argument_list
+          (string) @route_path
+        )
+      )
+    )
+  )
+  definition: (function_definition
+    name: (identifier) @name
+  )
+) @definition.route_handler
+'''
+
+TreeSitterSymbolExtractor.extend_language("python", "/path/to/fastapi.scm")
+```
+
+### Python: Django Models
+
+Detect Django model fields:
+
+```python
+django_query = '''
+; Django model fields
+(assignment
+  target: (identifier) @field_name
+  value: (call
+    function: (attribute
+      object: (identifier) @models
+      attribute: (identifier) @field_type
+    )
+  )
+) @definition.model_field
+
+; Django Meta classes
+(class_definition
+  name: (identifier) @name
+  (#match? @name "Meta")
+) @definition.meta_class
+'''
+
+TreeSitterSymbolExtractor.extend_language("python", "/path/to/django.scm")
+```
+
+### JavaScript: React Components
+
+Detect React functional components:
+
+```python
+react_query = '''
+; React functional components
+(function_declaration
+  name: (identifier) @name
+  (#match? @name "^[A-Z]")
+  body: (block
+    (return_statement
+      argument: (jsx_element)
+    )
+  )
+) @definition.react_component
+
+; React hooks
+(call_expression
+  function: (identifier) @hook_name
+  (#match? @hook_name "^use[A-Z]")
+) @definition.hook_usage
+'''
+
+TreeSitterSymbolExtractor.extend_language("javascript", "/path/to/react.scm")
+```
+
+## Registering New Languages
+
+### Example: Kotlin Support
+
+```python
+# Kotlin query patterns
+kotlin_query = '''
+; Function declarations
+(function_declaration
+  name: (identifier) @name
+) @definition.function
+
+; Class declarations
+(class_declaration
+  name: (identifier) @name
+) @definition.class
+
+; Property declarations
+(property_declaration
+  name: (identifier) @name
+) @definition.property
+
+; Data classes
+(class_declaration
+  modifiers: (modifiers
+    (modifier) @data_modifier
+    (#match? @data_modifier "data")
+  )
+  name: (identifier) @name
+) @definition.data_class
+'''
+
+# Register the language
+TreeSitterSymbolExtractor.register_language(
+    name="kotlin",
+    extensions=[".kt", ".kts"],
+    query_files=["kotlin.scm"],
+    query_dirs=["/path/to/custom/queries"]
+)
+```
+
+### Example: Custom DSL
+
+```python
+# Register a custom domain-specific language
+TreeSitterSymbolExtractor.register_language(
+    name="my_dsl",
+    extensions=[".mydsl"],
+    query_files=["base.scm", "advanced.scm"],
+    query_dirs=[
+        "/company/shared/queries",
+        "/project/local/queries"
+    ]
+)
+```
+
+## Real-World Examples
+
+### Team Coding Standards
+
+Enforce naming conventions across your codebase:
+
+```python
+# naming_standards.scm
+(function_definition
+  name: (identifier) @name
+  (#match? @name "^(get|set|create|update|delete)_")
+) @definition.crud_function
+
+(class_definition
+  name: (identifier) @name
+  (#match? @name ".*Service$")
+) @definition.service_class
+
+(class_definition
+  name: (identifier) @name
+  (#match? @name ".*Repository$") 
+) @definition.repository_class
+```
+
+### API Documentation Generation
+
+Extract API endpoints for documentation:
+
+```python
+# api_patterns.scm
+(decorated_definition
+  (decorator_list
+    (decorator
+      (call
+        (attribute
+          attribute: (identifier) @http_method
+          (#match? @http_method "(get|post|put|delete|patch)")
+        )
+      )
+    )
+  )
+  definition: (function_definition
+    name: (identifier) @name
+  )
+) @definition.api_endpoint
+```
+
+### Testing Pattern Detection
+
+Identify test functions and test classes:
+
+```python
+# test_patterns.scm
+(function_definition
+  name: (identifier) @name
+  (#match? @name "^test_")
+) @definition.test_function
+
+(class_definition
+  name: (identifier) @name
+  (#match? @name "^Test")
+) @definition.test_class
+
+(function_definition
+  decorators: (decorator_list
+    (decorator
+      (identifier) @decorator
+      (#match? @decorator "pytest.fixture")
+    )
+  )
+  name: (identifier) @name
+) @definition.test_fixture
+```
+
+## Best Practices
+
+### Query Organization
+
+1. **Separate by Purpose**: Create different .scm files for different concerns
+   ```
+   queries/
+   ├── python/
+   │   ├── tags.scm          # Base language patterns
+   │   ├── django.scm        # Django-specific patterns
+   │   ├── fastapi.scm       # FastAPI-specific patterns
+   │   └── testing.scm       # Testing patterns
+   ```
+
+2. **Use Descriptive Names**: Make symbol types self-documenting
+   ```python
+   # Good
+   @definition.api_endpoint
+   @definition.model_field
+   @definition.test_fixture
+   
+   # Avoid
+   @definition.thing
+   @definition.item
+   ```
+
+3. **Comment Your Queries**: Explain complex patterns
+   ```scheme
+   ; Match Django model fields with specific field types
+   ; Captures both the field name and field type for analysis
+   (assignment
+     target: (identifier) @field_name
+     value: (call
+       function: (attribute
+         object: (identifier) @models
+         attribute: (identifier) @field_type
+       )
+     )
+   ) @definition.model_field
+   ```
+
+### Performance Considerations
+
+1. **Use Specific Patterns**: More specific queries are faster
+   ```scheme
+   ; Better - specific pattern
+   (function_definition
+     name: (identifier) @name
+     (#match? @name "^handle_")
+   ) @definition.handler
+   
+   ; Slower - overly broad pattern
+   (function_definition
+     name: (identifier) @name
+   ) @definition.function
+   ```
+
+2. **Combine Related Patterns**: Group similar patterns in one file
+3. **Test Query Performance**: Use logging to monitor query compilation time
+
+### Version Control
+
+1. **Include Query Files**: Check .scm files into version control
+2. **Document Extensions**: Maintain a README explaining custom queries
+3. **Team Sharing**: Use shared query directories for team standards
+
+## Troubleshooting
+
+### Common Query Errors
+
+1. **Invalid Field Name**: Field doesn't exist in grammar
+   ```
+   Error: Invalid field name at row 5, column 10: slice
+   ```
+   **Solution**: Check the tree-sitter grammar documentation for valid field names
+
+2. **Invalid Node Type**: Node type doesn't exist
+   ```
+   Error: Invalid node type at row 3, column 5: decorator_list
+   ```
+   **Solution**: Use tree-sitter playground to explore the actual AST structure
+
+3. **Query Compilation Failed**: Syntax error in query
+   ```
+   Error: Query compile error for ext .py
+   ```
+   **Solution**: Validate query syntax, check parentheses matching
+
+### Debugging Tips
+
+1. **Enable Debug Logging**:
+   ```python
+   import logging
+   logging.getLogger('kit.tree_sitter_symbol_extractor').setLevel(logging.DEBUG)
+   ```
+
+2. **Test Queries Incrementally**: Start with simple patterns and add complexity
+
+3. **Use Tree-sitter Playground**: Visualize AST structure at https://tree-sitter.github.io/tree-sitter/playground
+
+4. **Check Language Support**: Verify the language is available in tree-sitter-language-pack
+
+### Reset and Recovery
+
+If you encounter issues with cached queries:
+
+```python
+# Reset all plugins and start fresh
+TreeSitterSymbolExtractor.reset_plugins()
+
+# Re-register your extensions
+TreeSitterSymbolExtractor.extend_language("python", "your_query.scm")
+```
+
+## Advanced Usage
+
+### Multiple Query Directories
+
+Load queries from multiple locations with fallback priority:
+
+```python
+TreeSitterSymbolExtractor.register_language(
+    name="python",
+    extensions=[".py"],
+    query_files=["base.scm", "company.scm", "project.scm"],
+    query_dirs=[
+        "/project/queries",           # Highest priority
+        "/company/shared/queries",    # Medium priority
+        "/home/user/.kit/queries"     # Lowest priority
+    ]
+)
+```
+
+### Dynamic Query Loading
+
+Load queries based on project configuration:
+
+```python
+import yaml
+
+def load_project_queries():
+    with open('.kit-config.yml') as f:
+        config = yaml.safe_load(f)
+    
+    for lang_config in config.get('languages', []):
+        TreeSitterSymbolExtractor.extend_language(
+            language=lang_config['name'],
+            query_file=lang_config['query_file']
+        )
+
+# Usage in project setup
+load_project_queries()
+```
+
+### Integration with CI/CD
+
+Use plugins to enforce coding standards:
+
+```python
+# check_standards.py
+def check_naming_conventions(file_path: str) -> List[str]:
+    violations = []
+    
+    with open(file_path) as f:
+        code = f.read()
+    
+    symbols = TreeSitterSymbolExtractor.extract_symbols(
+        file_path.suffix, code
+    )
+    
+    for symbol in symbols:
+        if symbol['type'] == 'function' and not symbol['name'].startswith(('get_', 'set_', 'create_')):
+            violations.append(f"Function {symbol['name']} doesn't follow naming convention")
+    
+    return violations
+```
+
+This plugin system makes Kit's symbol extraction completely customizable while maintaining excellent performance and backward compatibility. You can now adapt Kit to work with any codebase's specific patterns and conventions! 

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from importlib.resources import files  # type: ignore[no-redef]
+from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, cast
 
 from tree_sitter_language_pack import get_language, get_parser
@@ -24,15 +25,79 @@ LANGUAGES: dict[str, str] = {
 }
 
 
+class LanguagePlugin:
+    """Represents a language plugin with query files and configuration."""
+
+    def __init__(
+        self, name: str, extensions: List[str], query_files: List[str], query_dirs: Optional[List[str]] = None
+    ):
+        self.name = name
+        self.extensions = extensions
+        self.query_files = query_files  # List of .scm files to load
+        self.query_dirs = query_dirs or []  # Additional directories to search for queries
+
+
 class TreeSitterSymbolExtractor:
     """
-    Multi-language symbol extractor using tree-sitter queries (tags.scm).
-    Register new languages by adding to LANGUAGES and providing a tags.scm.
+    Multi-language symbol extractor using tree-sitter queries with plugin support.
+
+    Supports:
+    - Extending existing languages with additional query files
+    - Registering completely new languages
+    - Loading multiple .scm files per language
     """
 
     LANGUAGES = set(LANGUAGES.keys())
     _parsers: ClassVar[dict[str, Any]] = {}
     _queries: ClassVar[dict[str, Any]] = {}
+    _custom_languages: ClassVar[dict[str, LanguagePlugin]] = {}
+    _language_extensions: ClassVar[dict[str, List[str]]] = {}  # lang_name -> list of additional .scm files
+
+    @classmethod
+    def register_language(
+        cls, name: str, extensions: List[str], query_files: List[str], query_dirs: Optional[List[str]] = None
+    ) -> None:
+        """Register a completely new language.
+
+        Args:
+            name: Language name (should match tree-sitter-language-pack name)
+            extensions: List of file extensions (e.g., ['.kt', '.kts'])
+            query_files: List of .scm query files to load
+            query_dirs: Optional additional directories to search for queries
+        """
+        plugin = LanguagePlugin(name, extensions, query_files, query_dirs)
+        cls._custom_languages[name] = plugin
+
+        # Update LANGUAGES mapping
+        for ext in extensions:
+            LANGUAGES[ext] = name
+            cls.LANGUAGES.add(ext)
+
+        # Clear cached parsers and queries for this language
+        for ext in extensions:
+            cls._parsers.pop(ext, None)
+            cls._queries.pop(ext, None)
+
+        logger.info(f"Registered new language: {name} with extensions {extensions}")
+
+    @classmethod
+    def extend_language(cls, language: str, query_file: str) -> None:
+        """Extend an existing language with additional query patterns.
+
+        Args:
+            language: Language name (e.g., 'python', 'javascript')
+            query_file: Path to additional .scm file (relative to queries dir or absolute)
+        """
+        if language not in cls._language_extensions:
+            cls._language_extensions[language] = []
+        cls._language_extensions[language].append(query_file)
+
+        # Clear cached queries for this language
+        extensions_to_clear = [ext for ext, lang in LANGUAGES.items() if lang == language]
+        for ext in extensions_to_clear:
+            cls._queries.pop(ext, None)
+
+        logger.info(f"Extended language {language} with query file: {query_file}")
 
     @classmethod
     def get_parser(cls, ext: str) -> Optional[Any]:
@@ -45,6 +110,124 @@ class TreeSitterSymbolExtractor:
         return cls._parsers[ext]
 
     @classmethod
+    def _load_query_files(cls, lang_name: str) -> str:
+        """Load and combine all query files for a language."""
+        query_contents = []
+
+        # Check if this is a custom language
+        if lang_name in cls._custom_languages:
+            plugin = cls._custom_languages[lang_name]
+
+            # Load files from custom plugin
+            for query_file in plugin.query_files:
+                try:
+                    # Check if it's an absolute path
+                    if Path(query_file).is_absolute():
+                        with open(query_file, "r", encoding="utf-8") as f:
+                            content = f.read()
+                    else:
+                        # Search in plugin directories first, then built-in
+                        content = None
+                        for query_dir in plugin.query_dirs:
+                            try:
+                                query_path = Path(query_dir) / query_file
+                                if query_path.exists():
+                                    with open(query_path, "r", encoding="utf-8") as f:
+                                        content = f.read()
+                                    break
+                            except (FileNotFoundError, OSError):
+                                continue
+
+                        # Fallback to built-in queries directory
+                        if content is None:
+                            try:
+                                package_files = files("kit.queries").joinpath(lang_name)
+                                query_path = package_files.joinpath(query_file)
+                                content = query_path.read_text(encoding="utf-8")
+                            except (FileNotFoundError, OSError):
+                                logger.warning(f"Could not find query file {query_file} for language {lang_name}")
+                                continue
+
+                    if content:
+                        query_contents.append(content)
+                        logger.debug(f"Loaded query file: {query_file}")
+
+                except Exception as e:
+                    logger.warning(f"Error loading query file {query_file}: {e}")
+                    continue
+        else:
+            # Load built-in language queries
+            try:
+                # First try to load all .scm files in the language directory
+                package_files = files("kit.queries").joinpath(lang_name)
+
+                # Try to load tags.scm first (backward compatibility)
+                try:
+                    tags_path = package_files.joinpath("tags.scm")
+                    tags_content = tags_path.read_text(encoding="utf-8")
+                    query_contents.append(tags_content)
+                    logger.debug(f"Loaded base tags.scm for {lang_name}")
+                except (FileNotFoundError, OSError) as e:
+                    if lang_name == "tsx":
+                        # Fallback to TypeScript query definitions
+                        tags_path = files("kit.queries").joinpath("typescript").joinpath("tags.scm")
+                        tags_content = tags_path.read_text(encoding="utf-8")
+                        query_contents.append(tags_content)
+                    else:
+                        logger.warning(f"No base tags.scm found for {lang_name}: {e}")
+
+                # Load any additional .scm files in the directory
+                try:
+                    if hasattr(package_files, "iterdir"):
+                        for query_file in package_files.iterdir():
+                            if query_file.name.endswith(".scm") and query_file.name != "tags.scm":
+                                try:
+                                    content = query_file.read_text(encoding="utf-8")
+                                    query_contents.append(content)
+                                    logger.debug(f"Loaded additional query file: {query_file.name}")
+                                except Exception as e:
+                                    logger.warning(f"Error loading {query_file.name}: {e}")
+                except AttributeError:
+                    # package_files doesn't support iterdir, skip additional files
+                    pass
+
+            except Exception as e:
+                logger.warning(f"Error loading built-in queries for {lang_name}: {e}")
+
+        # Load language extensions
+        if lang_name in cls._language_extensions:
+            for extension_file in cls._language_extensions[lang_name]:
+                try:
+                    # Check if it's an absolute path
+                    if Path(extension_file).is_absolute():
+                        with open(extension_file, "r", encoding="utf-8") as f:
+                            content = f.read()
+                            query_contents.append(content)
+                            logger.debug(f"Loaded extension file: {extension_file}")
+                    else:
+                        # Try to load from built-in queries directory
+                        try:
+                            package_files = files("kit.queries").joinpath(lang_name)
+                            query_path = package_files.joinpath(extension_file)
+                            content = query_path.read_text(encoding="utf-8")
+                            query_contents.append(content)
+                            logger.debug(f"Loaded extension file: {extension_file}")
+                        except (FileNotFoundError, OSError):
+                            logger.warning(f"Could not find extension file {extension_file} for language {lang_name}")
+
+                except Exception as e:
+                    logger.warning(f"Error loading extension file {extension_file}: {e}")
+
+        # Combine all query contents
+        combined_query = "\n\n".join(query_contents)
+        if not combined_query.strip():
+            logger.warning(f"No query content loaded for language {lang_name}")
+            return ""
+
+        logger.debug(f"Combined {len(query_contents)} query files for {lang_name}")
+        return combined_query
+
+    @classmethod
     def get_query(cls, ext: str) -> Optional[Any]:
         if ext not in LANGUAGES:
             logger.debug(f"get_query: Extension {ext} not supported.")
@@ -55,35 +238,62 @@ class TreeSitterSymbolExtractor:
 
         lang_name = LANGUAGES[ext]
         logger.debug(f"get_query: lang={lang_name}")
-        resource_package = f"kit.queries.{lang_name}"
+
         try:
+            # Load and combine all query files for this language
+            combined_query_content = cls._load_query_files(lang_name)
+
+            if not combined_query_content.strip():
+                logger.warning(f"No query content available for language {lang_name}")
+                return None
+
             language = get_language(cast(Any, lang_name))  # type: ignore[arg-type]
-
-            # Prefer tags under the language's own directory (e.g., tsx/) but
-            # gracefully fall back to TypeScript's tags if none are found.
-            package_files = files("kit.queries").joinpath(lang_name)
-            tags_path = package_files.joinpath("tags.scm")
-
-            try:
-                tags_content = tags_path.read_text(encoding="utf-8")
-            except (FileNotFoundError, OSError) as e:
-                if lang_name == "tsx":
-                    # Fallback to TypeScript query definitions – they work for most TSX constructs.
-                    tags_path = files("kit.queries").joinpath("typescript").joinpath("tags.scm")
-                    tags_content = tags_path.read_text(encoding="utf-8")
-                else:
-                    raise e
-            query = language.query(tags_content)
+            query = language.query(combined_query_content)
             cls._queries[ext] = query
             logger.debug(f"get_query: Query loaded successfully for ext {ext}")
             return query
-        except (FileNotFoundError, ModuleNotFoundError) as e:
-            logger.warning(f"get_query: tags.scm not found for {lang_name} in package {resource_package}: {e}")
-            return None
+
         except Exception as e:
             logger.error(f"get_query: Query compile error for ext {ext}: {e}")
-            logger.error(traceback.format_exc())  # Log stack trace
+            logger.error(traceback.format_exc())
             return None
+
+    @classmethod
+    def list_supported_languages(cls) -> Dict[str, List[str]]:
+        """Return a mapping of language names to their supported extensions."""
+        lang_to_extensions = {}
+        for ext, lang in LANGUAGES.items():
+            if lang not in lang_to_extensions:
+                lang_to_extensions[lang] = []
+            lang_to_extensions[lang].append(ext)
+        return lang_to_extensions
+
+    @classmethod
+    def reset_plugins(cls) -> None:
+        """Reset all custom languages and extensions. Useful for testing."""
+        cls._custom_languages.clear()
+        cls._language_extensions.clear()
+        cls._queries.clear()
+        cls._parsers.clear()
+
+        # Reset LANGUAGES to original state
+        global LANGUAGES
+        original_languages = {
+            ".py": "python",
+            ".js": "javascript",
+            ".go": "go",
+            ".rs": "rust",
+            ".hcl": "hcl",
+            ".tf": "hcl",
+            ".ts": "typescript",
+            ".tsx": "tsx",
+            ".c": "c",
+            ".rb": "ruby",
+            ".java": "java",
+        }
+        LANGUAGES.clear()
+        LANGUAGES.update(original_languages)
+        cls.LANGUAGES = set(LANGUAGES.keys())
 
     @staticmethod
     def extract_symbols(ext: str, source_code: str) -> List[Dict[str, Any]]:

--- a/tests/test_tree_sitter_plugin_system.py
+++ b/tests/test_tree_sitter_plugin_system.py
@@ -1,0 +1,753 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from kit.tree_sitter_symbol_extractor import LanguagePlugin, TreeSitterSymbolExtractor
+
+
+class TestLanguagePlugin:
+    """Tests for the LanguagePlugin class."""
+
+    def test_language_plugin_initialization(self):
+        """Test that LanguagePlugin initializes correctly."""
+        plugin = LanguagePlugin(
+            name="test_lang",
+            extensions=[".test", ".tst"],
+            query_files=["base.scm", "advanced.scm"],
+            query_dirs=["/path/to/queries"],
+        )
+
+        assert plugin.name == "test_lang"
+        assert plugin.extensions == [".test", ".tst"]
+        assert plugin.query_files == ["base.scm", "advanced.scm"]
+        assert plugin.query_dirs == ["/path/to/queries"]
+
+    def test_language_plugin_default_query_dirs(self):
+        """Test that query_dirs defaults to empty list."""
+        plugin = LanguagePlugin(name="test_lang", extensions=[".test"], query_files=["base.scm"])
+
+        assert plugin.query_dirs == []
+
+
+class TestBackwardCompatibility:
+    """Tests to ensure existing functionality continues to work."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_existing_languages_still_supported(self):
+        """Test that all existing languages are still supported."""
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+
+        # Verify core languages are present
+        expected_languages = {"python", "javascript", "go", "rust", "hcl", "typescript", "tsx", "c", "ruby", "java"}
+
+        for lang in expected_languages:
+            assert lang in supported, f"Language {lang} should be supported"
+
+    def test_existing_extensions_mapped_correctly(self):
+        """Test that file extensions map to correct languages."""
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+
+        # Test specific mappings
+        assert ".py" in supported["python"]
+        assert ".js" in supported["javascript"]
+        assert ".go" in supported["go"]
+        assert ".rs" in supported["rust"]
+        assert ".tf" in supported["hcl"]
+        assert ".hcl" in supported["hcl"]
+        assert ".ts" in supported["typescript"]
+        assert ".tsx" in supported["tsx"]
+        assert ".c" in supported["c"]
+        assert ".rb" in supported["ruby"]
+        assert ".java" in supported["java"]
+
+    @patch("kit.tree_sitter_symbol_extractor.get_parser")
+    @patch("kit.tree_sitter_symbol_extractor.get_language")
+    @patch("kit.tree_sitter_symbol_extractor.files")
+    def test_backward_compatible_query_loading(self, mock_files, mock_get_language, mock_get_parser):
+        """Test that existing tags.scm loading still works."""
+        # Mock file system
+        mock_package = MagicMock()
+        mock_tags_file = MagicMock()
+        mock_tags_file.read_text.return_value = "(function_definition) @definition.function"
+        mock_package.joinpath.return_value = mock_tags_file
+        mock_files.return_value.joinpath.return_value = mock_package
+
+        # Mock language and parser
+        mock_language = MagicMock()
+        mock_query = MagicMock()
+        mock_language.query.return_value = mock_query
+        mock_get_language.return_value = mock_language
+
+        # Test query loading
+        query = TreeSitterSymbolExtractor.get_query(".py")
+
+        assert query == mock_query
+        mock_language.query.assert_called_once()
+        mock_files.assert_called_with("kit.queries")
+
+
+class TestLanguageExtension:
+    """Tests for extending existing languages with additional queries."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_extend_language_with_absolute_path(self):
+        """Test extending a language with absolute path to query file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("(test_pattern) @definition.test")
+            query_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.extend_language("python", query_file)
+
+            # Verify extension was added
+            assert "python" in TreeSitterSymbolExtractor._language_extensions
+            assert query_file in TreeSitterSymbolExtractor._language_extensions["python"]
+        finally:
+            Path(query_file).unlink()
+
+    def test_extend_language_multiple_files(self):
+        """Test extending a language with multiple query files."""
+        files = []
+        try:
+            for i in range(3):
+                with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+                    f.write(f"(pattern_{i}) @definition.test_{i}")
+                    files.append(f.name)
+                    TreeSitterSymbolExtractor.extend_language("python", f.name)
+
+            # Verify all extensions were added
+            extensions = TreeSitterSymbolExtractor._language_extensions["python"]
+            assert len(extensions) == 3
+            for file_path in files:
+                assert file_path in extensions
+        finally:
+            for file_path in files:
+                Path(file_path).unlink()
+
+    def test_extend_nonexistent_language(self):
+        """Test extending a language that doesn't exist creates extension list."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("(pattern) @definition.test")
+            query_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.extend_language("nonexistent", query_file)
+
+            # Should create new extension list
+            assert "nonexistent" in TreeSitterSymbolExtractor._language_extensions
+            assert query_file in TreeSitterSymbolExtractor._language_extensions["nonexistent"]
+        finally:
+            Path(query_file).unlink()
+
+    def test_extend_language_clears_cache(self):
+        """Test that extending a language clears cached queries."""
+        # Pre-populate cache
+        TreeSitterSymbolExtractor._queries[".py"] = MagicMock()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("(pattern) @definition.test")
+            query_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.extend_language("python", query_file)
+
+            # Cache should be cleared
+            assert ".py" not in TreeSitterSymbolExtractor._queries
+        finally:
+            Path(query_file).unlink()
+
+
+class TestNewLanguageRegistration:
+    """Tests for registering completely new languages."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_register_new_language(self):
+        """Test registering a new language."""
+        TreeSitterSymbolExtractor.register_language(
+            name="kotlin", extensions=[".kt", ".kts"], query_files=["kotlin.scm"], query_dirs=["/custom/queries"]
+        )
+
+        # Verify registration
+        assert "kotlin" in TreeSitterSymbolExtractor._custom_languages
+        plugin = TreeSitterSymbolExtractor._custom_languages["kotlin"]
+        assert plugin.name == "kotlin"
+        assert plugin.extensions == [".kt", ".kts"]
+        assert plugin.query_files == ["kotlin.scm"]
+        assert plugin.query_dirs == ["/custom/queries"]
+
+    def test_register_language_updates_mappings(self):
+        """Test that registering a language updates extension mappings."""
+        from kit.tree_sitter_symbol_extractor import LANGUAGES
+
+        original_kt_mapping = LANGUAGES.get(".kt")
+
+        TreeSitterSymbolExtractor.register_language(
+            name="kotlin", extensions=[".kt", ".kts"], query_files=["kotlin.scm"]
+        )
+
+        # Verify mappings updated
+        assert LANGUAGES[".kt"] == "kotlin"
+        assert LANGUAGES[".kts"] == "kotlin"
+        assert ".kt" in TreeSitterSymbolExtractor.LANGUAGES
+        assert ".kts" in TreeSitterSymbolExtractor.LANGUAGES
+
+        # Clean up
+        if original_kt_mapping is None:
+            LANGUAGES.pop(".kt", None)
+        else:
+            LANGUAGES[".kt"] = original_kt_mapping
+
+    def test_register_language_clears_cache(self):
+        """Test that registering a language clears relevant caches."""
+        # Pre-populate caches
+        TreeSitterSymbolExtractor._parsers[".kt"] = MagicMock()
+        TreeSitterSymbolExtractor._queries[".kt"] = MagicMock()
+
+        TreeSitterSymbolExtractor.register_language(name="kotlin", extensions=[".kt"], query_files=["kotlin.scm"])
+
+        # Caches should be cleared
+        assert ".kt" not in TreeSitterSymbolExtractor._parsers
+        assert ".kt" not in TreeSitterSymbolExtractor._queries
+
+    def test_register_language_overwrites_existing(self):
+        """Test that registering overwrites existing custom language."""
+        # Register initial language
+        TreeSitterSymbolExtractor.register_language(name="kotlin", extensions=[".kt"], query_files=["old.scm"])
+
+        # Register updated language
+        TreeSitterSymbolExtractor.register_language(
+            name="kotlin", extensions=[".kt", ".kts"], query_files=["new.scm"], query_dirs=["/new/path"]
+        )
+
+        # Verify overwrite
+        plugin = TreeSitterSymbolExtractor._custom_languages["kotlin"]
+        assert plugin.extensions == [".kt", ".kts"]
+        assert plugin.query_files == ["new.scm"]
+        assert plugin.query_dirs == ["/new/path"]
+
+
+class TestQueryLoading:
+    """Tests for the query loading system."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    @patch("kit.tree_sitter_symbol_extractor.files")
+    def test_load_builtin_queries_with_extensions(self, mock_files):
+        """Test loading built-in queries with extensions."""
+        # Mock built-in tags.scm
+        mock_package = MagicMock()
+        mock_tags_file = MagicMock()
+        mock_tags_file.read_text.return_value = "base_query"
+        mock_package.joinpath.return_value = mock_tags_file
+        mock_files.return_value.joinpath.return_value = mock_package
+
+        # Add extension
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("extension_query")
+            extension_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.extend_language("python", extension_file)
+
+            # Load combined queries
+            combined = TreeSitterSymbolExtractor._load_query_files("python")
+
+            assert "base_query" in combined
+            assert "extension_query" in combined
+        finally:
+            Path(extension_file).unlink()
+
+    def test_load_custom_language_queries(self):
+        """Test loading queries for custom languages."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create query files
+            query1_path = Path(temp_dir) / "base.scm"
+            query2_path = Path(temp_dir) / "advanced.scm"
+
+            query1_path.write_text("base_patterns")
+            query2_path.write_text("advanced_patterns")
+
+            # Register custom language
+            TreeSitterSymbolExtractor.register_language(
+                name="custom", extensions=[".custom"], query_files=["base.scm", "advanced.scm"], query_dirs=[temp_dir]
+            )
+
+            # Load queries
+            combined = TreeSitterSymbolExtractor._load_query_files("custom")
+
+            assert "base_patterns" in combined
+            assert "advanced_patterns" in combined
+
+    def test_load_queries_with_absolute_paths(self):
+        """Test loading queries with absolute file paths."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("absolute_path_query")
+            abs_query_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.register_language(
+                name="test_lang", extensions=[".test"], query_files=[abs_query_file]
+            )
+
+            combined = TreeSitterSymbolExtractor._load_query_files("test_lang")
+            assert "absolute_path_query" in combined
+        finally:
+            Path(abs_query_file).unlink()
+
+    def test_load_queries_priority_order(self):
+        """Test that queries are loaded in correct priority order."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create query file
+            query_path = Path(temp_dir) / "test.scm"
+            query_path.write_text("custom_query")
+
+            # Register language with multiple directories
+            TreeSitterSymbolExtractor.register_language(
+                name="test_lang", extensions=[".test"], query_files=["test.scm"], query_dirs=[temp_dir, "/nonexistent"]
+            )
+
+            combined = TreeSitterSymbolExtractor._load_query_files("test_lang")
+            assert "custom_query" in combined
+
+    def test_load_queries_handles_missing_files(self):
+        """Test that missing query files are handled gracefully."""
+        TreeSitterSymbolExtractor.register_language(
+            name="test_lang", extensions=[".test"], query_files=["nonexistent.scm"]
+        )
+
+        # Should not raise exception
+        combined = TreeSitterSymbolExtractor._load_query_files("test_lang")
+        assert combined == ""  # Empty string for no content
+
+    @patch("kit.tree_sitter_symbol_extractor.files")
+    def test_tsx_fallback_to_typescript(self, mock_files):
+        """Test that TSX falls back to TypeScript queries."""
+        # Mock TSX directory not existing
+        mock_tsx_package = MagicMock()
+        mock_tsx_tags = MagicMock()
+        mock_tsx_tags.read_text.side_effect = FileNotFoundError("Not found")
+        mock_tsx_package.joinpath.return_value = mock_tsx_tags
+
+        # Mock TypeScript fallback
+        mock_ts_package = MagicMock()
+        mock_ts_tags = MagicMock()
+        mock_ts_tags.read_text.return_value = "typescript_fallback"
+        mock_ts_package.joinpath.return_value = mock_ts_tags
+
+        def mock_joinpath(path):
+            if path == "tsx":
+                return mock_tsx_package
+            elif path == "typescript":
+                return mock_ts_package
+            return MagicMock()
+
+        mock_files.return_value.joinpath.side_effect = mock_joinpath
+
+        combined = TreeSitterSymbolExtractor._load_query_files("tsx")
+        assert "typescript_fallback" in combined
+
+
+class TestQueryCompilation:
+    """Tests for query compilation and caching."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    @patch("kit.tree_sitter_symbol_extractor.get_language")
+    @patch("kit.tree_sitter_symbol_extractor.TreeSitterSymbolExtractor._load_query_files")
+    def test_query_compilation_success(self, mock_load_files, mock_get_language):
+        """Test successful query compilation."""
+        mock_load_files.return_value = "(function_definition) @definition.function"
+
+        mock_language = MagicMock()
+        mock_query = MagicMock()
+        mock_language.query.return_value = mock_query
+        mock_get_language.return_value = mock_language
+
+        query = TreeSitterSymbolExtractor.get_query(".py")
+
+        assert query == mock_query
+        assert ".py" in TreeSitterSymbolExtractor._queries  # Should be cached
+
+    @patch("kit.tree_sitter_symbol_extractor.get_language")
+    @patch("kit.tree_sitter_symbol_extractor.TreeSitterSymbolExtractor._load_query_files")
+    def test_query_compilation_failure(self, mock_load_files, mock_get_language):
+        """Test query compilation failure handling."""
+        mock_load_files.return_value = "invalid query syntax"
+
+        mock_language = MagicMock()
+        mock_language.query.side_effect = Exception("Query compilation failed")
+        mock_get_language.return_value = mock_language
+
+        query = TreeSitterSymbolExtractor.get_query(".py")
+
+        assert query is None
+        assert ".py" not in TreeSitterSymbolExtractor._queries  # Should not cache failed queries
+
+    @patch("kit.tree_sitter_symbol_extractor.get_language")
+    @patch("kit.tree_sitter_symbol_extractor.TreeSitterSymbolExtractor._load_query_files")
+    def test_empty_query_content_handling(self, mock_load_files, mock_get_language):
+        """Test handling of empty query content."""
+        mock_load_files.return_value = ""  # Empty content
+
+        query = TreeSitterSymbolExtractor.get_query(".py")
+
+        assert query is None
+        mock_get_language.assert_not_called()  # Should not try to compile empty query
+
+    def test_query_caching(self):
+        """Test that queries are properly cached."""
+        mock_query = MagicMock()
+        TreeSitterSymbolExtractor._queries[".py"] = mock_query
+
+        # Should return cached query
+        query = TreeSitterSymbolExtractor.get_query(".py")
+        assert query == mock_query
+
+    def test_unsupported_extension(self):
+        """Test handling of unsupported file extensions."""
+        query = TreeSitterSymbolExtractor.get_query(".unknown")
+        assert query is None
+
+
+class TestIntrospection:
+    """Tests for introspection and debugging methods."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_list_supported_languages_builtin(self):
+        """Test listing built-in supported languages."""
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+
+        assert isinstance(supported, dict)
+        assert "python" in supported
+        assert ".py" in supported["python"]
+        assert "javascript" in supported
+        assert ".js" in supported["javascript"]
+
+    def test_list_supported_languages_with_custom(self):
+        """Test listing languages including custom ones."""
+        TreeSitterSymbolExtractor.register_language(
+            name="kotlin", extensions=[".kt", ".kts"], query_files=["kotlin.scm"]
+        )
+
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+
+        assert "kotlin" in supported
+        assert ".kt" in supported["kotlin"]
+        assert ".kts" in supported["kotlin"]
+
+    def test_list_supported_languages_grouped_correctly(self):
+        """Test that extensions are grouped by language correctly."""
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+
+        # HCL should have both .hcl and .tf
+        assert "hcl" in supported
+        hcl_extensions = supported["hcl"]
+        assert ".hcl" in hcl_extensions
+        assert ".tf" in hcl_extensions
+
+
+class TestPluginReset:
+    """Tests for plugin reset functionality."""
+
+    def test_reset_plugins_clears_custom_languages(self):
+        """Test that reset clears custom languages."""
+        TreeSitterSymbolExtractor.register_language(name="test_lang", extensions=[".test"], query_files=["test.scm"])
+
+        assert "test_lang" in TreeSitterSymbolExtractor._custom_languages
+
+        TreeSitterSymbolExtractor.reset_plugins()
+
+        assert len(TreeSitterSymbolExtractor._custom_languages) == 0
+
+    def test_reset_plugins_clears_extensions(self):
+        """Test that reset clears language extensions."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("test extension")
+            query_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.extend_language("python", query_file)
+            assert "python" in TreeSitterSymbolExtractor._language_extensions
+
+            TreeSitterSymbolExtractor.reset_plugins()
+
+            assert len(TreeSitterSymbolExtractor._language_extensions) == 0
+        finally:
+            Path(query_file).unlink()
+
+    def test_reset_plugins_clears_caches(self):
+        """Test that reset clears query and parser caches."""
+        # Populate caches
+        TreeSitterSymbolExtractor._queries[".py"] = MagicMock()
+        TreeSitterSymbolExtractor._parsers[".py"] = MagicMock()
+
+        TreeSitterSymbolExtractor.reset_plugins()
+
+        assert len(TreeSitterSymbolExtractor._queries) == 0
+        assert len(TreeSitterSymbolExtractor._parsers) == 0
+
+    def test_reset_plugins_restores_original_mappings(self):
+        """Test that reset restores original language mappings."""
+        from kit.tree_sitter_symbol_extractor import LANGUAGES
+
+        original_py_mapping = LANGUAGES[".py"]
+
+        # Register custom language that overwrites .py
+        TreeSitterSymbolExtractor.register_language(
+            name="custom_python", extensions=[".py"], query_files=["custom.scm"]
+        )
+
+        assert LANGUAGES[".py"] == "custom_python"
+
+        TreeSitterSymbolExtractor.reset_plugins()
+
+        assert LANGUAGES[".py"] == original_py_mapping
+
+
+class TestErrorHandling:
+    """Tests for error handling and edge cases."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_extend_language_with_nonexistent_file(self):
+        """Test extending language with non-existent file."""
+        # Should not raise exception
+        TreeSitterSymbolExtractor.extend_language("python", "/nonexistent/file.scm")
+
+        # Extension should still be registered (will fail at load time)
+        assert "python" in TreeSitterSymbolExtractor._language_extensions
+        assert "/nonexistent/file.scm" in TreeSitterSymbolExtractor._language_extensions["python"]
+
+    def test_register_language_with_empty_extensions(self):
+        """Test registering language with empty extensions list."""
+        TreeSitterSymbolExtractor.register_language(name="test_lang", extensions=[], query_files=["test.scm"])
+
+        assert "test_lang" in TreeSitterSymbolExtractor._custom_languages
+        plugin = TreeSitterSymbolExtractor._custom_languages["test_lang"]
+        assert plugin.extensions == []
+
+    def test_register_language_with_empty_query_files(self):
+        """Test registering language with empty query files list."""
+        TreeSitterSymbolExtractor.register_language(name="test_lang", extensions=[".test"], query_files=[])
+
+        assert "test_lang" in TreeSitterSymbolExtractor._custom_languages
+        plugin = TreeSitterSymbolExtractor._custom_languages["test_lang"]
+        assert plugin.query_files == []
+
+    @patch("builtins.open", side_effect=PermissionError("Permission denied"))
+    def test_load_queries_permission_error(self, mock_open):
+        """Test handling of permission errors when loading queries."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            query_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.register_language(
+                name="test_lang", extensions=[".test"], query_files=[query_file]
+            )
+
+            # Should handle permission error gracefully
+            combined = TreeSitterSymbolExtractor._load_query_files("test_lang")
+            assert combined == ""  # Empty due to error
+        finally:
+            Path(query_file).unlink()
+
+    def test_multiple_reset_calls(self):
+        """Test that multiple reset calls don't cause issues."""
+        TreeSitterSymbolExtractor.reset_plugins()
+        TreeSitterSymbolExtractor.reset_plugins()
+        TreeSitterSymbolExtractor.reset_plugins()
+
+        # Should not raise any exceptions
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+        assert len(supported) > 0
+
+
+class TestIntegrationScenarios:
+    """Integration tests for complex scenarios."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_mixed_builtin_and_custom_languages(self):
+        """Test scenario with both built-in and custom languages."""
+        # Register custom language
+        TreeSitterSymbolExtractor.register_language(name="kotlin", extensions=[".kt"], query_files=["kotlin.scm"])
+
+        # Extend built-in language
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+            f.write("extension query")
+            extension_file = f.name
+
+        try:
+            TreeSitterSymbolExtractor.extend_language("python", extension_file)
+
+            supported = TreeSitterSymbolExtractor.list_supported_languages()
+
+            # Should have both built-in and custom
+            assert "python" in supported
+            assert "kotlin" in supported
+            assert ".py" in supported["python"]
+            assert ".kt" in supported["kotlin"]
+
+            # Check internal state
+            assert "kotlin" in TreeSitterSymbolExtractor._custom_languages
+            assert "python" in TreeSitterSymbolExtractor._language_extensions
+        finally:
+            Path(extension_file).unlink()
+
+    def test_override_builtin_language(self):
+        """Test overriding a built-in language with custom registration."""
+        # Override Python with custom implementation
+        TreeSitterSymbolExtractor.register_language(
+            name="custom_python", extensions=[".py"], query_files=["custom_python.scm"]
+        )
+
+        from kit.tree_sitter_symbol_extractor import LANGUAGES
+
+        assert LANGUAGES[".py"] == "custom_python"
+
+        supported = TreeSitterSymbolExtractor.list_supported_languages()
+        assert "custom_python" in supported
+        assert ".py" in supported["custom_python"]
+
+    def test_complex_query_directory_hierarchy(self):
+        """Test complex scenario with multiple query directories."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create nested directory structure
+            base_dir = Path(temp_dir) / "base"
+            project_dir = Path(temp_dir) / "project"
+
+            base_dir.mkdir()
+            project_dir.mkdir()
+
+            # Create query files
+            (base_dir / "base.scm").write_text("base_query")
+            (project_dir / "project.scm").write_text("project_query")
+
+            TreeSitterSymbolExtractor.register_language(
+                name="complex_lang",
+                extensions=[".complex"],
+                query_files=["base.scm", "project.scm"],
+                query_dirs=[str(base_dir), str(project_dir)],
+            )
+
+            combined = TreeSitterSymbolExtractor._load_query_files("complex_lang")
+
+            assert "base_query" in combined
+            assert "project_query" in combined
+
+
+class TestConcurrency:
+    """Tests for thread safety and concurrent access."""
+
+    def setup_method(self):
+        """Reset plugins before each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        TreeSitterSymbolExtractor.reset_plugins()
+
+    def test_concurrent_language_registration(self):
+        """Test that concurrent language registration is safe."""
+        import threading
+        import time
+
+        def register_language(lang_name: str):
+            TreeSitterSymbolExtractor.register_language(
+                name=f"lang_{lang_name}", extensions=[f".{lang_name}"], query_files=[f"{lang_name}.scm"]
+            )
+            time.sleep(0.01)  # Small delay to increase chance of race conditions
+
+        threads = []
+        for i in range(10):
+            thread = threading.Thread(target=register_language, args=(str(i),))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # All languages should be registered
+        assert len(TreeSitterSymbolExtractor._custom_languages) == 10
+        for i in range(10):
+            assert f"lang_{i}" in TreeSitterSymbolExtractor._custom_languages
+
+    def test_concurrent_extension_and_query_access(self):
+        """Test concurrent extension and query access."""
+        import threading
+
+        def extend_language():
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".scm", delete=False) as f:
+                f.write("test query")
+                TreeSitterSymbolExtractor.extend_language("python", f.name)
+                Path(f.name).unlink()
+
+        def access_query():
+            # This might return None due to missing dependencies, but shouldn't crash
+            TreeSitterSymbolExtractor.get_query(".py")
+
+        threads = []
+        for _ in range(5):
+            threads.append(threading.Thread(target=extend_language))
+            threads.append(threading.Thread(target=access_query))
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Should not crash and should have extensions registered
+        assert "python" in TreeSitterSymbolExtractor._language_extensions


### PR DESCRIPTION
This pull request introduces significant enhancements to the `TreeSitterSymbolExtractor` class, enabling greater flexibility in language support through a plugin-based system. It also includes a minor addition to the documentation configuration. The key changes are grouped into two themes: enhancements to the symbol extraction system and updates to documentation.

### Enhancements to the Symbol Extraction System:
* Introduced a new `LanguagePlugin` class to represent custom language plugins with query files and configurations. This allows users to register new languages or extend existing ones with additional query files. (`src/kit/tree_sitter_symbol_extractor.py`)
* Added `register_language` and `extend_language` methods to enable dynamic registration of new languages and extension of existing languages with additional `.scm` query files. (`src/kit/tree_sitter_symbol_extractor.py`)
* Implemented `_load_query_files` to load and combine query files for a language, supporting both built-in and custom queries. This method ensures backward compatibility and handles language-specific fallbacks (e.g., TypeScript for TSX). (`src/kit/tree_sitter_symbol_extractor.py`)
* Refactored `get_query` to use the new `_load_query_files` method for assembling query content, improving modularity and extensibility. (`src/kit/tree_sitter_symbol_extractor.py`)
* Added utility methods `list_supported_languages` and `reset_plugins` to provide an overview of supported languages and reset customizations, respectively. These are particularly useful for testing and debugging. (`src/kit/tree_sitter_symbol_extractor.py`)

### Updates to Documentation:
* Added a new page, `"core-concepts/plugin-system"`, to the sidebar navigation in the Astro documentation configuration, reflecting the new plugin system. (`docs/astro.config.mjs`)