### PR TITLE
refactor: make _strip_model_prefix generic to remove any prefix before first slash

### DIFF
--- a/src/kit/pr_review/cost_tracker.py
+++ b/src/kit/pr_review/cost_tracker.py
@@ -251,22 +251,9 @@ class CostTracker:
         - openrouter/meta-llama/llama-3.3-70b -> meta-llama/llama-3.3-70b
         - gpt-4o -> gpt-4o (unchanged)
         """
-        # Common prefixes to strip
-        prefixes_to_strip = [
-            "vertex_ai/",
-            "openrouter/",
-            "together/",
-            "groq/",
-            "fireworks/",
-            "perplexity/",
-            "replicate/",
-            "bedrock/",
-            "azure/",
-        ]
-
-        for prefix in prefixes_to_strip:
-            if model_name.startswith(prefix):
-                return model_name[len(prefix) :]
+        # Remove anything before the first "/"
+        if "/" in model_name:
+            return model_name.split("/", 1)[1]
 
         return model_name
 

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "0.6.3"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Decription

This is a follow up of #65. The providers strip down was statically defined but it might happen that some remappings don't fit, for example, instead of `bedrock/` I need to use `awsbedrock/` (which happens to be an issue in my case)

This PR relaxes the prefix strip down.

## Tasks

- Replace specific prefix list with generic approach that removes anything before first '/'
- Update tests to reflect the new generic behavior
- All provider prefixes now stripped consistently regardless of provider name
- Maintains backward compatibility while being more flexible for new providers