### PR TITLE
feat: add --repo-path option to use existing repositories

### DIFF
--- a/docs/src/content/docs/pr-reviewer/cicd.mdx
+++ b/docs/src/content/docs/pr-reviewer/cicd.mdx
@@ -443,6 +443,46 @@ jobs:
           KIT_ANTHROPIC_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
+### Repository Optimization Workflows
+
+Use `--repo-path` in CI/CD environments to optimize performance and handle special cases:
+
+#### Pre-Cloned Repository Workflow
+
+```yaml
+name: Optimized Review with Pre-Cloned Repo
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for comprehensive analysis
+          
+      - name: AI Review with Local Repository
+        run: |
+          pip install cased-kit
+          
+          # Use the checked-out repository directly
+          kit review --repo-path . ${{ github.event.pull_request.html_url }}
+        env:
+          KIT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIT_ANTHROPIC_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+<Aside type="tip">
+**Performance Benefit**: Using `--repo-path .` with a pre-checkout saves 30-90 seconds per review by skipping the clone step, especially valuable for large repositories or high-volume workflows.
+</Aside>
+
 ## Cost Monitoring
 
 ### Review Cost Tracking

--- a/docs/src/content/docs/pr-reviewer/configuration.mdx
+++ b/docs/src/content/docs/pr-reviewer/configuration.mdx
@@ -584,6 +584,33 @@ cp ~/.kit/review-config.yaml ~/.kit/review-config.yaml.backup
 **Pro Tip**: Start with a simple configuration and gradually add complexity. Use `--dry-run` mode to test changes before applying them to live reviews.
 </Aside>
 
+## Repository Configuration Options
+
+### Using Existing Local Repositories
+
+Skip cloning and use an existing local repository for analysis:
+
+```bash
+# Use existing repository instead of cloning
+kit review --repo-path /path/to/existing/repo https://github.com/owner/repo/pull/123
+
+# Works with any other flags
+kit review --repo-path ~/projects/myproject --model gpt-4.1-nano https://github.com/owner/repo/pull/123
+
+# Can be combined with configuration files
+kit review --repo-path /workspace/repo --config custom-config.yaml https://github.com/owner/repo/pull/123
+```
+
+<Aside type="caution">
+**Important**: When using `--repo-path`, the analysis is performed against the current state of your local repository, which may not reflect the main branch. Kit will display a warning to remind you of this.
+</Aside>
+
+**Benefits of using existing repositories:**
+- **Faster analysis**: Skip cloning time for large repositories
+- **Local development**: Analyze PRs against your working copy with local changes
+- **Network efficiency**: No need to download repositories you already have
+- **Bandwidth savings**: Useful for large repositories or limited internet connections
+
 ---
 
 [← Back to PR Reviewer Overview](/pr-reviewer/) 

--- a/docs/src/content/docs/pr-reviewer/examples.mdx
+++ b/docs/src/content/docs/pr-reviewer/examples.mdx
@@ -128,6 +128,57 @@ kit review --priority=low \
 - Test coverage suggestions
 - Performance optimizations
 
+### Local Development Workflow
+
+```bash
+# Analyze PR against your local working copy
+kit review --repo-path ~/projects/myapp \
+  --model gpt-4.1-mini \
+  https://github.com/company/myapp/pull/456
+```
+
+**Typical output focus**:
+- Compatibility with your local changes
+- Analysis against current branch state
+- Integration testing considerations
+- Merge conflict potential
+
+<Aside type="tip">
+**Local Development Pro Tip**: Use `--repo-path` when you want to analyze how a PR integrates with your local changes or when working on a feature branch that's not yet pushed.
+</Aside>
+
+### Large Repository Optimization
+
+```bash
+# Skip cloning large repositories you already have locally
+kit review --repo-path /workspace/large-monorepo \
+  --model claude-sonnet-4 \
+  --priority high,medium \
+  https://github.com/company/monorepo/pull/789
+```
+
+**Benefits**:
+- Save 5-15 minutes of cloning time for large repos
+- Preserve bandwidth for remote/mobile development
+- Use your existing repository cache
+- Work with repositories that have complex setup requirements
+
+### Offline Development Support
+
+```bash
+# Work offline with cached repositories
+kit review --repo-path /local/cache/project \
+  --model ollama:qwen2.5-coder:latest \
+  --dry-run \
+  https://github.com/company/project/pull/123
+```
+
+**Use case**:
+- Limited or expensive internet connectivity
+- Air-gapped development environments
+- Local-only testing and validation
+- Offline model usage with Ollama
+
 ## Team Workflow Examples
 
 ### Startup Team (Budget-Conscious)

--- a/docs/src/content/docs/pr-reviewer/integration.mdx
+++ b/docs/src/content/docs/pr-reviewer/integration.mdx
@@ -41,6 +41,31 @@ kit review -p https://github.com/owner/repo/pull/123
 
 **Output**: Just the raw review content with no status messages or formatting. Ideal for automation and piping workflows.
 
+## Repository Options
+
+### Using Existing Repositories
+
+```bash
+# Skip cloning with existing local repository
+kit review --repo-path /path/to/repo https://github.com/owner/repo/pull/123
+
+# Combine with dry-run mode for local testing
+kit review --repo-path ~/projects/myapp --dry-run https://github.com/company/myapp/pull/456
+
+# Use with plain mode for piping workflows
+kit review --repo-path /workspace/project -p https://github.com/company/project/pull/789
+```
+
+<Aside type="note">
+**Repository State Warning**: When using `--repo-path`, kit analyzes the current state of your local repository, which may differ from the main branch. A warning message will be displayed to remind you of this.
+</Aside>
+
+**When to use `--repo-path`:**
+- **Large repositories**: Skip cloning time for repos you already have locally
+- **Local development**: Analyze PRs against your working copy with uncommitted changes
+- **Bandwidth constraints**: Useful for large repositories or limited internet connections
+- **Offline workflows**: Work with cached repositories when internet is unavailable
+
 ## Priority Filtering
 
 Focus reviews on what matters most:
@@ -354,7 +379,5 @@ if __name__ == "__main__":
     success = post_to_dashboard(review)
     print(f"Dashboard update: {'✅' if success else '❌'}")
 ```
-
----
 
 [← Back to PR Reviewer Overview](/pr-reviewer/) 

--- a/src/kit/cli.py
+++ b/src/kit/cli.py
@@ -444,6 +444,9 @@ def review_pr(
     agentic_turns: int = typer.Option(
         15, "--agentic-turns", help="Number of analysis turns for agentic mode (default: 15)"
     ),
+    repo_path: Optional[str] = typer.Option(
+        None, "--repo-path", help="Path to existing repository (skips cloning, uses current state)"
+    ),
 ):
     """Review a GitHub PR using kit's repository intelligence and AI analysis.
 
@@ -462,6 +465,8 @@ def review_pr(
     kit review --model gpt-4.1-nano <pr-url>                      # Ultra budget
     kit review --model claude-opus-4-20250514 <pr-url>            # Premium
     kit review --agentic --agentic-turns 8 <pr-url>               # Budget agentic
+    kit review --repo-path /path/to/repo <pr-url>                 # Use existing repo
+    kit review --repo-path ~/projects/myapp <pr-url>              # Local development
     """
     from kit.pr_review.config import ReviewConfig
     from kit.pr_review.reviewer import PRReviewer
@@ -502,11 +507,16 @@ def review_pr(
 
     try:
         # Load configuration with profile support
-        review_config = ReviewConfig.from_file(config, profile)
+        review_config = ReviewConfig.from_file(config, profile, repo_path=repo_path)
 
         # Show profile info if one is being used
         if profile and not plain:
             typer.echo(f"📋 Using profile: {profile}")
+
+        # Show repo path info if one is being used
+        if repo_path and not plain:
+            typer.echo(f"📁 Using existing repository: {repo_path}")
+            typer.echo("⚠️ WARNING: Analysis will be performed against current local state")
 
         # Parse priority filter
         if priority:
@@ -651,6 +661,9 @@ def summarize_pr(
     update_pr_body: bool = typer.Option(
         False, "--update-pr-body", "-u", help="Update the PR description with the summary"
     ),
+    repo_path: Optional[str] = typer.Option(
+        None, "--repo-path", help="Path to existing repository (skips cloning, uses current state)"
+    ),
 ):
     """Generate a concise summary of a GitHub PR using kit's repository intelligence.
 
@@ -663,6 +676,7 @@ def summarize_pr(
     kit summarize --model gpt-4.1-nano <pr-url>                 # Ultra budget model
     kit summarize --output summary.md <pr-url>                  # Save to file
     kit summarize --update-pr-body <pr-url>                     # Add summary to PR description
+    kit summarize --repo-path /path/to/repo <pr-url>            # Use existing repo
 
     Cost: ~$0.005-0.02 per summary (much cheaper than review)
     """
@@ -671,7 +685,12 @@ def summarize_pr(
 
     try:
         # Load configuration (can reuse same config as review)
-        review_config = ReviewConfig.from_file(config)
+        review_config = ReviewConfig.from_file(config, repo_path=repo_path)
+
+        # Show repo path info if one is being used
+        if repo_path and not plain:
+            typer.echo(f"📁 Using existing repository: {repo_path}")
+            typer.echo("⚠️ WARNING: Analysis will be performed against current local state")
 
         # Override model if specified
         if model:

--- a/src/kit/pr_review/config.py
+++ b/src/kit/pr_review/config.py
@@ -157,14 +157,17 @@ class ReviewConfig:
     # Custom context profile
     profile: Optional[str] = None  # Profile name to use
     profile_context: Optional[str] = None  # Loaded profile context
+    # Existing repository path (skips cloning when provided)
+    repo_path: Optional[str] = None  # Path to existing repository to use for analysis
 
     @classmethod
-    def from_file(cls, config_path: Optional[str] = None, profile: Optional[str] = None) -> "ReviewConfig":
+    def from_file(cls, config_path: Optional[str] = None, profile: Optional[str] = None, repo_path: Optional[str] = None) -> "ReviewConfig":
         """Load configuration from file or environment variables.
 
         Args:
             config_path: Path to config file
             profile: Profile name to load custom context from
+            repo_path: Path to existing repository to use for analysis
         """
         if config_path is None:
             config_path = os.path.expanduser("~/.kit/review-config.yaml")
@@ -300,6 +303,7 @@ class ReviewConfig:
             max_review_size_mb=review_data.get("max_review_size_mb", 5.0),
             profile=profile,
             profile_context=profile_context,
+            repo_path=repo_path,
         )
 
     def create_default_config_file(self, config_path: Optional[str] = None) -> str:

--- a/src/kit/pr_review/debug.py
+++ b/src/kit/pr_review/debug.py
@@ -13,6 +13,7 @@ def review_pr(
     pr_url: str,
     config: Optional[str] = typer.Option(None, "--config", "-c", help="Path to config file"),
     dry_run: bool = typer.Option(True, "--dry-run/--post", help="Run analysis but do not post comment"),
+    repo_path: Optional[str] = typer.Option(None, "--repo-path", help="Path to existing repository (skips cloning)"),
 ):
     """Review a GitHub PR using kit analysis for testing."""
     try:
@@ -21,9 +22,9 @@ def review_pr(
 
         # Load configuration
         if config:
-            review_config = ReviewConfig.from_file(config)
+            review_config = ReviewConfig.from_file(config, repo_path=repo_path)
         else:
-            review_config = ReviewConfig.from_file()
+            review_config = ReviewConfig.from_file(repo_path=repo_path)
 
         # Override post_as_comment if dry run
         if dry_run:

--- a/src/kit/pr_review/summarizer.py
+++ b/src/kit/pr_review/summarizer.py
@@ -327,8 +327,16 @@ class PRSummarizer(PRReviewer):
 
             # Clone repository for analysis (reusing reviewer logic)
             if len(files) > 0 and self.config.clone_for_analysis:
-                if not quiet:
-                    print("Cloning repository for analysis...")
+                # Check if using existing repository
+                if self.config.repo_path:
+                    # Show warning when using existing repository
+                    if not quiet:
+                        print("⚠️ WARNING: Using existing repository - results may not reflect the main branch")
+                        print(f"Using existing repository at: {self.config.repo_path}")
+                else:
+                    if not quiet:
+                        print("Cloning repository for analysis...")
+
                 repo_path = self.get_repo_for_analysis(owner, repo, pr_details)
 
                 # Run async analysis

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -35,7 +35,9 @@ def test_pr_url_parsing():
     reviewer = PRReviewer(config)
 
     # Test valid PR URL
-    owner, repo, pr_number = reviewer.parse_pr_url("https://github.com/cased/kit/pull/47")
+    owner, repo, pr_number = reviewer.parse_pr_url(
+        "https://github.com/cased/kit/pull/47"
+    )
     assert owner == "cased"
     assert repo == "kit"
     assert pr_number == 47
@@ -54,7 +56,9 @@ def test_cost_tracker_anthropic():
     tracker = CostTracker()
 
     # Test Claude 3.5 Sonnet pricing
-    tracker.track_llm_usage(LLMProvider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1000, 500)
+    tracker.track_llm_usage(
+        LLMProvider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1000, 500
+    )
 
     expected_cost = (1000 / 1_000_000) * 3.00 + (500 / 1_000_000) * 15.00
     assert abs(tracker.breakdown.llm_cost_usd - expected_cost) < 0.0001
@@ -98,11 +102,15 @@ def test_cost_tracker_multiple_calls():
     tracker = CostTracker()
 
     # First call
-    tracker.track_llm_usage(LLMProvider.ANTHROPIC, "claude-3-5-haiku-20241022", 500, 200)
+    tracker.track_llm_usage(
+        LLMProvider.ANTHROPIC, "claude-3-5-haiku-20241022", 500, 200
+    )
     first_cost = tracker.breakdown.llm_cost_usd
 
     # Second call
-    tracker.track_llm_usage(LLMProvider.ANTHROPIC, "claude-3-5-haiku-20241022", 300, 150)
+    tracker.track_llm_usage(
+        LLMProvider.ANTHROPIC, "claude-3-5-haiku-20241022", 300, 150
+    )
 
     # Should accumulate
     assert tracker.breakdown.llm_input_tokens == 800
@@ -114,7 +122,9 @@ def test_cost_tracker_reset():
     """Test cost tracker reset functionality."""
     tracker = CostTracker()
 
-    tracker.track_llm_usage(LLMProvider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1000, 500)
+    tracker.track_llm_usage(
+        LLMProvider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1000, 500
+    )
     assert tracker.breakdown.llm_cost_usd > 0
 
     tracker.reset()
@@ -132,10 +142,16 @@ def test_model_prefix_detection():
         == "meta-llama/llama-3.1-8b-instruct"
     )
 
-    assert CostTracker._strip_model_prefix("openrouter/anthropic/claude-3.5-sonnet") == "anthropic/claude-3.5-sonnet"
+    assert (
+        CostTracker._strip_model_prefix("openrouter/anthropic/claude-3.5-sonnet")
+        == "anthropic/claude-3.5-sonnet"
+    )
 
     # Test Together AI prefixes
-    assert CostTracker._strip_model_prefix("together/meta-llama/Llama-3-8b-chat-hf") == "meta-llama/Llama-3-8b-chat-hf"
+    assert (
+        CostTracker._strip_model_prefix("together/meta-llama/Llama-3-8b-chat-hf")
+        == "meta-llama/Llama-3-8b-chat-hf"
+    )
 
     assert (
         CostTracker._strip_model_prefix("together/mistralai/Mixtral-8x7B-Instruct-v0.1")
@@ -145,27 +161,44 @@ def test_model_prefix_detection():
     # Test Groq prefixes
     assert CostTracker._strip_model_prefix("groq/llama3-8b-8192") == "llama3-8b-8192"
 
-    assert CostTracker._strip_model_prefix("groq/mixtral-8x7b-32768") == "mixtral-8x7b-32768"
+    assert (
+        CostTracker._strip_model_prefix("groq/mixtral-8x7b-32768")
+        == "mixtral-8x7b-32768"
+    )
 
     # Test Fireworks AI prefixes
     assert (
-        CostTracker._strip_model_prefix("fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct")
+        CostTracker._strip_model_prefix(
+            "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct"
+        )
         == "accounts/fireworks/models/llama-v3p1-8b-instruct"
     )
 
     # Test Replicate prefixes
-    assert CostTracker._strip_model_prefix("replicate/meta/llama-2-70b-chat") == "meta/llama-2-70b-chat"
+    assert (
+        CostTracker._strip_model_prefix("replicate/meta/llama-2-70b-chat")
+        == "meta/llama-2-70b-chat"
+    )
 
     # Test models without prefixes (should return as-is)
     assert CostTracker._strip_model_prefix("gpt-4o") == "gpt-4o"
 
-    assert CostTracker._strip_model_prefix("claude-3-5-sonnet-20241022") == "claude-3-5-sonnet-20241022"
+    assert (
+        CostTracker._strip_model_prefix("claude-3-5-sonnet-20241022")
+        == "claude-3-5-sonnet-20241022"
+    )
 
     # Test complex model names with multiple slashes - now strips first prefix generically
-    assert CostTracker._strip_model_prefix("provider/org/model/version/variant") == "org/model/version/variant"
+    assert (
+        CostTracker._strip_model_prefix("provider/org/model/version/variant")
+        == "org/model/version/variant"
+    )
 
     # Test vertex_ai prefix
-    assert CostTracker._strip_model_prefix("vertex_ai/claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
+    assert (
+        CostTracker._strip_model_prefix("vertex_ai/claude-sonnet-4-20250514")
+        == "claude-sonnet-4-20250514"
+    )
 
 
 def test_cost_tracking_with_prefixed_models():
@@ -187,7 +220,9 @@ def test_cost_tracking_with_prefixed_models():
     # Since "together/anthropic/claude-3-5-sonnet-20241022" doesn't match
     # the exact pricing key, it will use fallback pricing
     with patch("builtins.print"):  # Suppress warning output
-        tracker.track_llm_usage(LLMProvider.ANTHROPIC, "together/claude-3-5-sonnet-20241022", 800, 400)
+        tracker.track_llm_usage(
+            LLMProvider.ANTHROPIC, "together/claude-3-5-sonnet-20241022", 800, 400
+        )
 
     # Should extract claude-3-5-sonnet-20241022 and use its pricing
     expected_cost = (800 / 1_000_000) * 3.00 + (400 / 1_000_000) * 15.00
@@ -200,7 +235,9 @@ def test_cost_tracking_unknown_prefixed_models():
 
     with patch("builtins.print") as mock_print:
         # Test completely unknown prefixed model
-        tracker.track_llm_usage(LLMProvider.OPENAI, "newprovider/unknown/model-v1", 1000, 500)
+        tracker.track_llm_usage(
+            LLMProvider.OPENAI, "newprovider/unknown/model-v1", 1000, 500
+        )
 
         # Should print warning about unknown pricing
         mock_print.assert_called()
@@ -277,7 +314,9 @@ def test_pr_reviewer_with_prefixed_models():
     assert reviewer.config.llm.model == "openrouter/gpt-4o-mini"
 
     # Cost tracker should handle the prefixed model correctly
-    reviewer.cost_tracker.track_llm_usage(LLMProvider.OPENAI, "openrouter/gpt-4o-mini", 500, 250)
+    reviewer.cost_tracker.track_llm_usage(
+        LLMProvider.OPENAI, "openrouter/gpt-4o-mini", 500, 250
+    )
 
     # Should extract base model for pricing
     assert reviewer.cost_tracker.breakdown.llm_cost_usd > 0
@@ -328,7 +367,9 @@ def test_complex_prefixed_model_names():
 
     for original_model, expected_result in complex_models:
         base_model = CostTracker._strip_model_prefix(original_model)
-        assert base_model == expected_result, f"Expected {expected_result}, got {base_model}"
+        assert (
+            base_model == expected_result
+        ), f"Expected {expected_result}, got {base_model}"
 
 
 def test_provider_prefix_detection():
@@ -367,7 +408,9 @@ def test_cost_tracking_edge_cases_with_prefixes():
 
     # Test model with provider prefix but unknown base model
     with patch("builtins.print") as mock_print:
-        tracker.track_llm_usage(LLMProvider.ANTHROPIC, "openrouter/unknown/mystery-model-v1", 1000, 500)
+        tracker.track_llm_usage(
+            LLMProvider.ANTHROPIC, "openrouter/unknown/mystery-model-v1", 1000, 500
+        )
 
         # Should warn about unknown pricing
         mock_print.assert_called()
@@ -421,12 +464,17 @@ def test_validator_empty_review():
 
 def test_validator_vague_review():
     """Test validator detects vague reviews."""
-    vague_review = "This looks good. Maybe consider some improvements. Seems fine overall."
+    vague_review = (
+        "This looks good. Maybe consider some improvements. Seems fine overall."
+    )
 
     validation = validate_review_quality(vague_review, "diff", ["file.py"])
 
     assert validation.metrics["vague_statements"] > 0
-    assert any("Review doesn't reference any changed files" in issue for issue in validation.issues)
+    assert any(
+        "Review doesn't reference any changed files" in issue
+        for issue in validation.issues
+    )
 
 
 def test_validator_no_file_references():
@@ -436,7 +484,10 @@ def test_validator_no_file_references():
     validation = validate_review_quality(review, "diff", ["main.py", "test.py"])
 
     assert validation.metrics["file_references"] == 0
-    assert any("Review doesn't reference any changed files" in issue for issue in validation.issues)
+    assert any(
+        "Review doesn't reference any changed files" in issue
+        for issue in validation.issues
+    )
 
 
 def test_validator_change_coverage():
@@ -1010,20 +1061,320 @@ Overall assessment: Needs review."""
         assert _strip_thinking_tokens(None) is None
 
     def test_pr_reviewer_no_thinking_tokens(self):
-        """Test PR reviewer preserves content without thinking tokens."""
+        """Test that normal responses without thinking tokens are not modified."""
         from kit.pr_review.reviewer import _strip_thinking_tokens
 
-        response = """## Code Review
+        input_text = "This is a normal response without any thinking tokens."
+        output = _strip_thinking_tokens(input_text)
+        assert output == input_text
 
-This is a clean review comment with no thinking tokens.
 
-### Issues
-- Issue 1
-- Issue 2
+class TestExistingRepoPath:
+    """Test using existing repository path functionality."""
 
-### Recommendations
-- Fix issue 1
-- Address issue 2"""
+    def test_config_with_repo_path(self):
+        """Test ReviewConfig with repo_path parameter."""
+        config = ReviewConfig(
+            github=GitHubConfig(token="test"),
+            llm=LLMConfig(
+                provider=LLMProvider.ANTHROPIC, model="claude-4-sonnet", api_key="test"
+            ),
+            repo_path="/path/to/existing/repo",
+        )
+        assert config.repo_path == "/path/to/existing/repo"
 
-        result = _strip_thinking_tokens(response)
-        assert result == response
+    def test_config_from_file_with_repo_path(self):
+        """Test ReviewConfig.from_file with repo_path parameter."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            config_data = {
+                "github": {"token": "test-token"},
+                "llm": {
+                    "provider": "anthropic",
+                    "model": "claude-4-sonnet",
+                    "api_key": "test-key",
+                },
+            }
+            yaml.dump(config_data, f)
+            temp_config_path = f.name
+
+        try:
+            config = ReviewConfig.from_file(
+                temp_config_path, repo_path="/custom/repo/path"
+            )
+            assert config.repo_path == "/custom/repo/path"
+        finally:
+            os.unlink(temp_config_path)
+
+    @patch("kit.pr_review.reviewer.requests.Session")
+    @patch("pathlib.Path.exists")
+    def test_get_repo_for_analysis_with_existing_path(
+        self, mock_exists, mock_session_class
+    ):
+        """Test get_repo_for_analysis uses existing repo path when configured."""
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        config = ReviewConfig(
+            github=GitHubConfig(token="test"),
+            llm=LLMConfig(
+                provider=LLMProvider.ANTHROPIC, model="claude-4-sonnet", api_key="test"
+            ),
+            repo_path="/existing/repo",
+        )
+
+        reviewer = PRReviewer(config)
+
+        # Mock the Path.exists and git directory check
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("pathlib.Path.__truediv__") as mock_path_div:
+                mock_git_path = Mock()
+                mock_git_path.exists.return_value = True
+                mock_path_div.return_value = mock_git_path
+
+                pr_details = {"head": {"sha": "abc123"}}
+                result = reviewer.get_repo_for_analysis("owner", "repo", pr_details)
+
+                # Should resolve to the absolute path and not use cache
+                assert "/existing/repo" in result
+
+    @patch("kit.pr_review.reviewer.requests.Session")
+    @patch("pathlib.Path.exists")
+    def test_get_repo_for_analysis_nonexistent_path(
+        self, mock_exists, mock_session_class
+    ):
+        """Test get_repo_for_analysis raises error for nonexistent repo path."""
+        mock_exists.return_value = False
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        config = ReviewConfig(
+            github=GitHubConfig(token="test"),
+            llm=LLMConfig(
+                provider=LLMProvider.ANTHROPIC, model="claude-4-sonnet", api_key="test"
+            ),
+            repo_path="/nonexistent/repo",
+        )
+
+        reviewer = PRReviewer(config)
+
+        pr_details = {"head": {"sha": "abc123"}}
+
+        with pytest.raises(
+            ValueError, match="Specified repository path does not exist"
+        ):
+            reviewer.get_repo_for_analysis("owner", "repo", pr_details)
+
+    @patch("kit.pr_review.reviewer.requests.Session")
+    @patch("pathlib.Path.exists")
+    def test_get_repo_for_analysis_not_git_repo(self, mock_exists, mock_session_class):
+        """Test get_repo_for_analysis raises error for non-git directory."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        config = ReviewConfig(
+            github=GitHubConfig(token="test"),
+            llm=LLMConfig(
+                provider=LLMProvider.ANTHROPIC, model="claude-4-sonnet", api_key="test"
+            ),
+            repo_path="/not/a/git/repo",
+        )
+
+        reviewer = PRReviewer(config)
+
+        with patch("pathlib.Path.exists") as mock_path_exists:
+            with patch("pathlib.Path.__truediv__") as mock_path_div:
+                # Path exists but .git directory doesn't
+                mock_path_exists.side_effect = lambda: True
+                mock_git_path = Mock()
+                mock_git_path.exists.return_value = False
+                mock_path_div.return_value = mock_git_path
+
+                pr_details = {"head": {"sha": "abc123"}}
+
+                with pytest.raises(
+                    ValueError, match="Specified path is not a git repository"
+                ):
+                    reviewer.get_repo_for_analysis("owner", "repo", pr_details)
+
+    @patch("kit.pr_review.reviewer.requests.Session")
+    @patch("kit.pr_review.reviewer.subprocess.run")
+    @patch("builtins.print")
+    def test_review_pr_with_existing_repo_warning(
+        self, mock_print, mock_subprocess, mock_session_class
+    ):
+        """Test that warning message is displayed when using existing repository."""
+        # Setup similar to test_pr_review_dry_run but with repo_path
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # Mock PR details response
+        def mock_get(url):
+            mock_response = Mock()
+            if "pulls" in url and url.endswith("/47"):
+                mock_response.json.return_value = {
+                    "number": 47,
+                    "title": "Test PR",
+                    "user": {"login": "testuser"},
+                    "base": {
+                        "ref": "main",
+                        "repo": {"owner": {"login": "cased"}, "name": "kit"},
+                    },
+                    "head": {
+                        "ref": "feature",
+                        "sha": "abc123",
+                        "repo": {"owner": {"login": "cased"}, "name": "kit"},
+                    },
+                }
+            elif url.endswith("/files"):
+                mock_response.json.return_value = [
+                    {"filename": "test.py", "additions": 10, "deletions": 5}
+                ]
+            elif url.endswith("/comments"):
+                mock_response.json.return_value = {
+                    "html_url": "https://github.com/test/comment"
+                }
+            else:
+                mock_response.text = "diff content"
+            mock_response.raise_for_status = Mock()
+            return mock_response
+
+        mock_session.get = mock_get
+        mock_session.post = mock_get
+
+        # Mock existing repository path
+        config = ReviewConfig(
+            github=GitHubConfig(token="test"),
+            llm=LLMConfig(
+                provider=LLMProvider.ANTHROPIC, model="claude-4-sonnet", api_key="test"
+            ),
+            clone_for_analysis=True,
+            post_as_comment=False,
+            repo_path="/existing/repo",
+        )
+
+        reviewer = PRReviewer(config)
+
+        # Mock the repository path validation
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("pathlib.Path.__truediv__") as mock_path_div:
+                mock_git_path = Mock()
+                mock_git_path.exists.return_value = True
+                mock_path_div.return_value = mock_git_path
+
+                with patch("kit.pr_review.reviewer.Repository"):
+                    with patch(
+                        "kit.pr_review.reviewer.asyncio.run",
+                        return_value="Test analysis",
+                    ):
+                        reviewer.review_pr("https://github.com/cased/kit/pull/47")
+
+                        # Check that warning message was printed
+                        warning_calls = [
+                            call
+                            for call in mock_print.call_args_list
+                            if "WARNING: Using existing repository" in str(call)
+                        ]
+                        assert len(warning_calls) > 0
+
+                        # Check that the existing repo path was mentioned
+                        repo_path_calls = [
+                            call
+                            for call in mock_print.call_args_list
+                            if "/existing/repo" in str(call)
+                        ]
+                        assert len(repo_path_calls) > 0
+
+    @patch("kit.pr_review.agentic_reviewer.requests.Session")
+    @patch("kit.pr_review.agentic_reviewer.asyncio.run")
+    @patch("builtins.print")
+    def test_agentic_reviewer_with_repo_path(
+        self, mock_print, mock_asyncio_run, mock_session_class
+    ):
+        """Test AgenticPRReviewer with existing repository path and warning messages."""
+        from kit.pr_review.agentic_reviewer import AgenticPRReviewer
+
+        # Setup similar to test_review_pr_with_existing_repo_warning but for agentic reviewer
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # Mock PR details response
+        def mock_get(url):
+            mock_response = Mock()
+            if "pulls" in url and url.endswith("/47"):
+                mock_response.json.return_value = {
+                    "number": 47,
+                    "title": "Test Agentic PR",
+                    "user": {"login": "testuser"},
+                    "base": {
+                        "ref": "main",
+                        "repo": {"owner": {"login": "cased"}, "name": "kit"},
+                    },
+                    "head": {
+                        "ref": "feature",
+                        "sha": "abc123",
+                        "repo": {"owner": {"login": "cased"}, "name": "kit"},
+                    },
+                }
+            elif url.endswith("/files"):
+                mock_response.json.return_value = [
+                    {"filename": "test.py", "additions": 10, "deletions": 5}
+                ]
+            elif url.endswith("/comments"):
+                mock_response.json.return_value = {
+                    "html_url": "https://github.com/test/comment"
+                }
+            else:
+                mock_response.text = "diff content"
+            mock_response.raise_for_status = Mock()
+            return mock_response
+
+        mock_session.get = mock_get
+        mock_session.post = mock_get
+
+        # Mock existing repository path
+        config = ReviewConfig(
+            github=GitHubConfig(token="test"),
+            llm=LLMConfig(
+                provider=LLMProvider.ANTHROPIC, model="claude-4-sonnet", api_key="test"
+            ),
+            post_as_comment=False,
+            repo_path="/existing/repo",
+        )
+
+        # Mock the RepoCache to avoid path operation issues
+        with patch("kit.pr_review.agentic_reviewer.RepoCache") as mock_repo_cache_class:
+            mock_repo_cache = Mock()
+            mock_repo_cache_class.return_value = mock_repo_cache
+
+            reviewer = AgenticPRReviewer(config)
+
+            # Mock the repository path validation
+            with patch("pathlib.Path.exists", return_value=True):
+                with patch("pathlib.Path.__truediv__") as mock_path_div:
+                    mock_git_path = Mock()
+                    mock_git_path.exists.return_value = True
+                    mock_path_div.return_value = mock_git_path
+
+                    # Mock the agentic analysis to return a test result
+                    mock_asyncio_run.return_value = "Test agentic analysis result"
+
+                    # Call the full agentic review method
+                    reviewer.review_pr_agentic("https://github.com/cased/kit/pull/47")
+
+                    # Check that warning message was printed
+                    warning_calls = [
+                        call
+                        for call in mock_print.call_args_list
+                        if "WARNING: Using existing repository" in str(call)
+                    ]
+                    assert len(warning_calls) > 0
+
+                    # Check that the existing repo path was mentioned
+                    repo_path_calls = [
+                        call
+                        for call in mock_print.call_args_list
+                        if "/existing/repo" in str(call)
+                    ]
+                    assert len(repo_path_calls) > 0

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -719,7 +719,7 @@ class TestReviewIntegration:
             assert "Using profile: company-standards" in result.output
 
             # Verify config was loaded with profile
-            mock_config_from_file.assert_called_once_with(None, "company-standards")
+            mock_config_from_file.assert_called_once_with(None, "company-standards", repo_path=None)
 
     def test_profile_context_injection_standard_reviewer(self):
         """Test that profile context is injected into standard reviewer prompt."""

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

In some cases the code is already being cloned, for example when using `actions/checkout@v4`. This PR introduces a new optional flag to target a path where there repo is located.

Benefits:

- Optimize CI/CD workflows with already cloned repos
- Skip 30-90 second clone time for large repositories

## Tasks

- Add repo_path parameter to ReviewConfig class
- Update get_repo_for_analysis methods to skip cloning when repo_path is provided
- Add --repo-path CLI option to review and summarize commands
- Display warning messages when using existing repository (non-main branch analysis)
- Add comprehensive test coverage for repo-path functionality
- Update documentation with examples and use cases

