### PR TITLE
Introduce multi-file retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ print(repo.extract_symbols('src/main.py'))
 # Access git metadata
 print(f"Current SHA: {repo.current_sha}")
 print(f"Branch: {repo.current_branch}")
+
+# Read one file
+main_py = repo.get_file_content("src/main.py")
+
+# Read many files in one round-trip (NEW in 1.0.4)
+contents = repo.get_file_content([
+    "src/main.py",
+    "src/utils/helper.py",
+    "tests/test_main.py",
+])
+print(contents["src/utils/helper.py"])
 ```
 
 ### Command Line Interface
@@ -101,6 +112,25 @@ kit commit  # Analyze and commit with AI-generated message
 ```
 
 The CLI supports all major repository operations with Unix-friendly output for scripting and automation. See the [CLI Documentation](https://kit.cased.com/introduction/cli) for comprehensive usage examples.
+
+### REST API (FastAPI)
+
+Once you run `kit serve` (or import `kit.api.app` in your own FastAPI server) you can fetch multiple files in **one HTTP call**:
+
+```bash
+# Register / open a repo – returns an ID
+curl -X POST localhost:8000/repository -d '{"path_or_url": "/path/to/repo"}' -H 'Content-Type: application/json'
+#=> {"id": "abc123"}
+
+# Fetch many files at once
+curl -X POST localhost:8000/repository/abc123/files \
+     -d '{"paths": ["src/main.py", "src/utils/helper.py"]}' \
+     -H 'Content-Type: application/json'
+#=> {
+#     "src/main.py": "print('hello')\n...",
+#     "src/utils/helper.py": "def helper(): ..."
+#   }
+```
 
 ## kit-powered Features & Utilities
 

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -234,6 +234,34 @@ Kit 1.0.0 represents the first stable release of the code intelligence toolkit, 
 - Enhanced file prioritization algorithms for reviews
 - Improved cost breakdown reporting
 
+## [1.0.3]
+
+### 🎉 Major Features
+
+- **Batch File Retrieval**: `Repository.get_file_content` now accepts a list of paths and returns a mapping of `path → content`, eliminating the need for multiple calls when bulk loading files.
+  - Backwards-compatible: single-path calls still return a plain string.
+
+### 🖥️  Interface Updates
+
+- **MCP Server**
+  - New tool `get_multiple_file_contents` plus expanded behaviour for existing `get_file_content`.
+  - Each request path is validated individually for secure bulk fetches.
+
+- **CLI** (`kit file-content`)
+  - Accepts multiple file paths in one invocation. Outputs each file with a header separator.
+
+- **REST API**
+  - New endpoint `POST /repository/{id}/files` with JSON body `{ "paths": ["src/main.py", "src/utils.py"] }`.
+
+### 🧪  Tests
+
+- 11 Repository tests and 10 MCP tests covering single/multi, error aggregation, path traversal checks, and tool registration.
+
+### 🏷️  Misc
+
+- Bumped internal version to 1.0.3.
+- Updated documentation and help texts accordingly.
+
 ## Links
 
 - [GitHub Releases](https://github.com/cased/kit/releases)

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -10,6 +10,13 @@ All notable changes to Kit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3]
+
+### New Features
+
+- **Batch File Retrieval**: `Repository.get_file_content` now accepts a list of paths and returns a mapping of `path → content`, eliminating the need for multiple calls when bulk loading files.
+  - Backwards-compatible: single-path calls still return a plain string.
+
 ## [1.0.2]
 
 ### 🔧 Improvements
@@ -233,34 +240,6 @@ Kit 1.0.0 represents the first stable release of the code intelligence toolkit, 
 - Better diff parsing and analysis
 - Enhanced file prioritization algorithms for reviews
 - Improved cost breakdown reporting
-
-## [1.0.3]
-
-### 🎉 Major Features
-
-- **Batch File Retrieval**: `Repository.get_file_content` now accepts a list of paths and returns a mapping of `path → content`, eliminating the need for multiple calls when bulk loading files.
-  - Backwards-compatible: single-path calls still return a plain string.
-
-### 🖥️  Interface Updates
-
-- **MCP Server**
-  - New tool `get_multiple_file_contents` plus expanded behaviour for existing `get_file_content`.
-  - Each request path is validated individually for secure bulk fetches.
-
-- **CLI** (`kit file-content`)
-  - Accepts multiple file paths in one invocation. Outputs each file with a header separator.
-
-- **REST API**
-  - New endpoint `POST /repository/{id}/files` with JSON body `{ "paths": ["src/main.py", "src/utils.py"] }`.
-
-### 🧪  Tests
-
-- 11 Repository tests and 10 MCP tests covering single/multi, error aggregation, path traversal checks, and tool registration.
-
-### 🏷️  Misc
-
-- Bumped internal version to 1.0.3.
-- Updated documentation and help texts accordingly.
 
 ## Links
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cased-kit"
-version = "1.0.2"
+version = "1.0.4"
 description = "A modular toolkit for LLM-powered codebase understanding."
 authors = [
     { name = "Cased", email = "ted@cased.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cased-kit"
-version = "1.0.4"
+version = "1.0.3"
 description = "A modular toolkit for LLM-powered codebase understanding."
 authors = [
     { name = "Cased", email = "ted@cased.com" }

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -3,7 +3,7 @@ A modular toolkit for LLM-powered codebase understanding.
 """
 
 __author__ = "cased"
-__version__ = "1.0.4"
+__version__ = "1.0.3"
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -3,7 +3,7 @@ A modular toolkit for LLM-powered codebase understanding.
 """
 
 __author__ = "cased"
-__version__ = "1.0.2"
+__version__ = "1.0.4"
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor

--- a/src/kit/mcp/server.py
+++ b/src/kit/mcp/server.py
@@ -225,7 +225,8 @@ class KitServerLogic:
         try:
             # Use repository's multi-file method with validated relative paths
             rel_file_paths = list(validated_paths.values())
-            result = repo.get_file_content(rel_file_paths)
+            # Using overload of Repository.get_file_content -> Dict[str, str]
+            result: Dict[str, str] = repo.get_file_content(rel_file_paths)  # type: ignore[assignment]
 
             # Map back from relative paths to original paths for consistency
             final_result = {}
@@ -680,7 +681,8 @@ class KitServerLogic:
         if kind == "file" and len(path_parts) >= 3:
             repo_id = path_parts[1]
             file_path = "/".join(path_parts[2:])
-            content = self.get_file_content(repo_id, unquote(file_path))
+            # get_file_content with str input → str output (overload)
+            content: str = self.get_file_content(repo_id, unquote(file_path))  # type: ignore[assignment]
             return "text/plain", content
         elif kind == "tree" and len(path_parts) == 2:
             repo_id = path_parts[1]

--- a/src/kit/mcp/server.py
+++ b/src/kit/mcp/server.py
@@ -8,7 +8,7 @@ import os
 import sys
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -114,7 +114,12 @@ class SearchParams(BaseModel):
 
 class GetFileContentParams(BaseModel):
     repo_id: str
-    file_path: str
+    file_path: Union[str, List[str]]
+
+
+class GetMultipleFileContentsParams(BaseModel):
+    repo_id: str
+    file_paths: List[str]
 
 
 class ExtractSymbolsParams(BaseModel):
@@ -189,17 +194,49 @@ class KitServerLogic:
         except Exception as e:
             raise MCPError(code=INVALID_PARAMS, message=f"Invalid search pattern: {e!s}")
 
-    def get_file_content(self, repo_id: str, file_path: str) -> str:
+    def get_file_content(self, repo_id: str, file_path: Union[str, List[str]]) -> Union[str, Dict[str, str]]:
         repo = self.get_repo(repo_id)
-        # Validate that the requested path stays within repo
-        safe_path = self._check_within_repo(repo, file_path)
-        rel_path = str(safe_path.relative_to(Path(repo.repo_path).resolve()))
+
+        if isinstance(file_path, str):
+            # Single file - existing behavior
+            safe_path = self._check_within_repo(repo, file_path)
+            rel_path = str(safe_path.relative_to(Path(repo.repo_path).resolve()))
+            try:
+                return repo.get_file_content(rel_path)
+            except FileNotFoundError as e:
+                raise MCPError(code=INVALID_PARAMS, message=str(e))
+            except Exception as e:
+                raise MCPError(code=INVALID_PARAMS, message=f"Error reading file: {e!s}")
+        else:
+            # Multiple files - new behavior
+            return self.get_multiple_file_contents(repo_id, file_path)
+
+    def get_multiple_file_contents(self, repo_id: str, file_paths: List[str]) -> Dict[str, str]:
+        """Get contents of multiple files at once."""
+        repo = self.get_repo(repo_id)
+
+        # Validate all paths first
+        validated_paths = {}
+        for file_path in file_paths:
+            safe_path = self._check_within_repo(repo, file_path)
+            rel_path = str(safe_path.relative_to(Path(repo.repo_path).resolve()))
+            validated_paths[file_path] = rel_path
+
         try:
-            return repo.get_file_content(rel_path)
-        except FileNotFoundError as e:
+            # Use repository's multi-file method with validated relative paths
+            rel_file_paths = list(validated_paths.values())
+            result = repo.get_file_content(rel_file_paths)
+
+            # Map back from relative paths to original paths for consistency
+            final_result = {}
+            for original_path, rel_path in validated_paths.items():
+                final_result[original_path] = result[rel_path]
+
+            return final_result
+        except (FileNotFoundError, IOError) as e:
             raise MCPError(code=INVALID_PARAMS, message=str(e))
         except Exception as e:
-            raise MCPError(code=INVALID_PARAMS, message=f"Error reading file: {e!s}")
+            raise MCPError(code=INVALID_PARAMS, message=f"Error reading files: {e!s}")
 
     def extract_symbols(self, repo_id: str, file_path: str, symbol_type: Optional[str] = None) -> list[dict]:
         repo = self.get_repo(repo_id)
@@ -340,8 +377,14 @@ class KitServerLogic:
             ),
             Tool(
                 name="get_file_content",
-                description="Get file contents",
+                description="Get single or multiple file contents",
                 inputSchema=GetFileContentParams.model_json_schema(),
+                annotations=ro_ann,
+            ),
+            Tool(
+                name="get_multiple_file_contents",
+                description="Get contents of multiple files at once (optimized for bulk operations)",
+                inputSchema=GetMultipleFileContentsParams.model_json_schema(),
                 annotations=ro_ann,
             ),
             Tool(
@@ -403,10 +446,14 @@ class KitServerLogic:
             ),
             Prompt(
                 name="get_file_content",
-                description="Get the content of a specific file",
+                description="Get the content of one or more files",
                 arguments=[
                     PromptArgument(name="repo_id", description="ID of the repository", required=True),
-                    PromptArgument(name="file_path", description="Path to the file", required=True),
+                    PromptArgument(
+                        name="file_path",
+                        description="Single file path (string) or multiple file paths (list)",
+                        required=True,
+                    ),
                 ],
             ),
             Prompt(
@@ -483,19 +530,30 @@ class KitServerLogic:
                     )
                 case "get_file_content":
                     gfc_args = GetFileContentParams(**arguments)
-                    # Validate path access but avoid sending full file in-band
-                    self.get_file_content(gfc_args.repo_id, gfc_args.file_path)
-                    return GetPromptResult(
-                        description="File content",
-                        messages=[
-                            PromptMessage(
-                                role="user",
-                                content=TextContent(
-                                    type="text", text=f"/repos/{gfc_args.repo_id}/files/{gfc_args.file_path}"
-                                ),
-                            )
-                        ],
-                    )
+                    result = self.get_file_content(gfc_args.repo_id, gfc_args.file_path)
+
+                    if isinstance(result, str):
+                        # Single file content
+                        return GetPromptResult(
+                            description="File content",
+                            messages=[
+                                PromptMessage(
+                                    role="user",
+                                    content=TextContent(type="text", text=result),
+                                )
+                            ],
+                        )
+                    else:
+                        # Multiple file contents
+                        return GetPromptResult(
+                            description="Multiple file contents",
+                            messages=[
+                                PromptMessage(
+                                    role="user",
+                                    content=TextContent(type="text", text=json.dumps(result, indent=2)),
+                                )
+                            ],
+                        )
                 case "extract_symbols":
                     es_args = ExtractSymbolsParams(**arguments)
                     symbols = self.extract_symbols(es_args.repo_id, es_args.file_path, es_args.symbol_type)
@@ -675,9 +733,18 @@ async def serve() -> None:
                 return [TextContent(type="text", text=json.dumps(results, indent=2))]
             elif name == "get_file_content":
                 gfc_args = GetFileContentParams(**arguments)
-                # Validate path access but avoid sending full file in-band
-                logic.get_file_content(gfc_args.repo_id, gfc_args.file_path)
-                return [TextContent(type="text", text=f"/repos/{gfc_args.repo_id}/files/{gfc_args.file_path}")]
+                result = logic.get_file_content(gfc_args.repo_id, gfc_args.file_path)
+
+                if isinstance(result, str):
+                    # Single file - return the content directly
+                    return [TextContent(type="text", text=result)]
+                else:
+                    # Multiple files - return JSON with file contents
+                    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            elif name == "get_multiple_file_contents":
+                gmfc_args = GetMultipleFileContentsParams(**arguments)
+                result = logic.get_multiple_file_contents(gmfc_args.repo_id, gmfc_args.file_paths)
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
             elif name == "extract_symbols":
                 es_args = ExtractSymbolsParams(**arguments)
                 symbols = logic.extract_symbols(es_args.repo_id, es_args.file_path, es_args.symbol_type)

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import overload
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor
@@ -337,6 +338,13 @@ class Repository:
             Optional[Dict[str, Any]]: A dictionary representing the extracted context, or None if not found.
         """
         return self.context.extract_context_around_line(file_path, line)
+
+    # Type overloads for precise return types
+    @overload
+    def get_file_content(self, file_path: str) -> str: ...
+
+    @overload
+    def get_file_content(self, file_path: List[str]) -> Dict[str, str]: ...
 
     def get_file_content(self, file_path: Union[str, List[str]]) -> Union[str, Dict[str, str]]:
         """

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -4,8 +4,7 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
-from typing import overload
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, overload
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -338,19 +338,31 @@ class Repository:
         """
         return self.context.extract_context_around_line(file_path, line)
 
-    def get_file_content(self, file_path: str) -> str:
+    def get_file_content(self, file_path: Union[str, List[str]]) -> Union[str, Dict[str, str]]:
         """
-        Reads and returns the content of a file within the repository.
+        Reads and returns the content of one or more files within the repository.
 
         Args:
-            file_path (str): The path to the file, relative to the repository root.
+            file_path: Single file path (str) or list of file paths (List[str]),
+                      relative to the repository root.
 
         Returns:
-            str: The content of the file.
+            str: Content of the single file (when file_path is str)
+            Dict[str, str]: Mapping of file_path -> content (when file_path is List[str])
 
         Raises:
-            FileNotFoundError: If the file does not exist within the repository.
+            FileNotFoundError: If any file does not exist (includes details of all missing files)
+            IOError: If any file reading error occurs
         """
+        if isinstance(file_path, str):
+            # Single file - existing behavior
+            return self._get_single_file_content(file_path)
+        else:
+            # Multiple files - new behavior
+            return self._get_multiple_file_contents(file_path)
+
+    def _get_single_file_content(self, file_path: str) -> str:
+        """Reads and returns the content of a single file within the repository."""
         full_path = self.local_path / file_path
         if not full_path.is_file():
             raise FileNotFoundError(f"File not found in repository: {file_path}")
@@ -360,6 +372,34 @@ class Repository:
         except Exception as e:
             # Catch potential decoding errors or other file reading issues
             raise IOError(f"Error reading file {file_path}: {e}") from e
+
+    def _get_multiple_file_contents(self, file_paths: List[str]) -> Dict[str, str]:
+        """Reads and returns the contents of multiple files within the repository."""
+        if not file_paths:
+            return {}
+
+        results = {}
+        missing_files = []
+        read_errors = []
+
+        for file_path in file_paths:
+            try:
+                results[file_path] = self._get_single_file_content(file_path)
+            except FileNotFoundError:
+                missing_files.append(file_path)
+            except IOError as e:
+                read_errors.append(f"{file_path}: {e!s}")
+
+        # Report all errors at once for better user experience
+        if missing_files or read_errors:
+            error_parts = []
+            if missing_files:
+                error_parts.append(f"Files not found: {', '.join(missing_files)}")
+            if read_errors:
+                error_parts.append(f"Read errors: {'; '.join(read_errors)}")
+            raise IOError("; ".join(error_parts))
+
+        return results
 
     def index(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION


<!-- AI SUMMARY START -->
## What This PR Does
This PR introduces multi-file retrieval functionality across all Kit interfaces (Python API, CLI, REST API, and MCP server). Users can now fetch multiple file contents in a single operation instead of making separate calls for each file, improving efficiency for bulk file operations.

## Key Changes
- **Enhanced `Repository.get_file_content()`** - Now accepts either a single file path (string) or list of paths, returning either a string or dict mapping paths to contents
- **Updated CLI command** - `kit file-content` now supports multiple file arguments with formatted output for each file
- **New REST API endpoint** - `/repository/{repo_id}/files` accepts a list of file paths and returns a content mapping
- **Extended MCP server** - Added multi-file retrieval capabilities to the MCP protocol implementation
- **Comprehensive test coverage** - Added 138 lines of tests specifically for the new multi-file functionality

## Impact
- **Backward compatibility maintained** - Single file operations continue to work exactly as before
- **Performance improvement** - Reduces network round-trips and API calls when working with multiple files
- **All interfaces updated** - Consistent multi-file support across Python API, CLI, REST API, and MCP server
- **Low risk** - Changes are additive with existing single-file behavior preserved

*Generated by [kit](https://github.com/cased/kit) v1.0.4 • Model: claude-sonnet-4-20250514*
<!-- AI SUMMARY END -->