### PR TITLE
Initial cache control support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ contents = repo.get_file_content([
     "tests/test_main.py",
 ])
 print(contents["src/utils/helper.py"])
-```
+
 
 ### Command Line Interface
 
@@ -271,7 +271,6 @@ Generate intelligent commit messages from staged changes using the same reposito
 git add .       # Stage your changes
 kit commit      # Analyze and commit with AI-generated message
 ```
-
 
 ## Documentation
 

--- a/docs/src/content/docs/api/repository.mdx
+++ b/docs/src/content/docs/api/repository.mdx
@@ -61,7 +61,7 @@ repository_instance = Repository(path_or_url="/path/to/local/project")
 #     github_token="YOUR_GITHUB_TOKEN",  # Optional: For private repos
 #     cache_dir="/path/to/cache",        # Optional: For caching clones
 #     ref="v1.2.3",                       # Optional: Specific commit, tag, or branch
-#     cache_ttl_hours=2,                  # Optional: New in vNEXT
+#     cache_ttl_hours=2,                  # Optional: New in v1.2.0
 # )
 ```
 
@@ -71,7 +71,7 @@ repository_instance = Repository(path_or_url="/path/to/local/project")
 *   `github_token` (Optional[str]): A GitHub personal access token required for cloning private repositories. If not provided, automatically checks the `KIT_GITHUB_TOKEN` and `GITHUB_TOKEN` environment variables. Defaults to `None`.
 *   `cache_dir` (Optional[str]): Path to a directory for caching cloned repositories. Defaults to a system temporary directory.
 *   `ref` (Optional[str]): Git reference (commit SHA, tag, or branch) to checkout. For remote repositories, this determines which version to clone. For local repositories, this will checkout the specified ref. Defaults to `None`.
-*   `cache_ttl_hours` (Optional[float]): **New in vNEXT.** When cloning a remote repository, Kit stores the clone under `tmp/kit-repo-cache` (or your custom `cache_dir`).  On the *first* clone in each Python process Kit will delete any cached repo directory whose **modification time** is older than this many hours before continuing.  Pass `None` (default) or `0` to disable the cleanup.  You can also set the global environment variable `KIT_TMP_REPO_TTL_HOURS` to apply the policy process-wide without changing code.
+*   `cache_ttl_hours` (Optional[float]): **New in v1.2.0.** When cloning a remote repository, Kit stores the clone under `tmp/kit-repo-cache` (or your custom `cache_dir`).  On the *first* clone in each Python process Kit will delete any cached repo directory whose **modification time** is older than this many hours before continuing.  Pass `None` (default) or `0` to disable the cleanup.  You can also set the global environment variable `KIT_TMP_REPO_TTL_HOURS` to apply the policy process-wide without changing code.
 
 <Aside type="tip">
 **Automatic GitHub Token Pickup**

--- a/docs/src/content/docs/api/repository.mdx
+++ b/docs/src/content/docs/api/repository.mdx
@@ -60,7 +60,8 @@ repository_instance = Repository(path_or_url="/path/to/local/project")
 #     path_or_url="https://github.com/owner/repo-name", 
 #     github_token="YOUR_GITHUB_TOKEN",  # Optional: For private repos
 #     cache_dir="/path/to/cache",        # Optional: For caching clones
-#     ref="v1.2.3"                       # Optional: Specific commit, tag, or branch
+#     ref="v1.2.3",                       # Optional: Specific commit, tag, or branch
+#     cache_ttl_hours=2,                  # Optional: New in vNEXT
 # )
 ```
 
@@ -70,6 +71,7 @@ repository_instance = Repository(path_or_url="/path/to/local/project")
 *   `github_token` (Optional[str]): A GitHub personal access token required for cloning private repositories. If not provided, automatically checks the `KIT_GITHUB_TOKEN` and `GITHUB_TOKEN` environment variables. Defaults to `None`.
 *   `cache_dir` (Optional[str]): Path to a directory for caching cloned repositories. Defaults to a system temporary directory.
 *   `ref` (Optional[str]): Git reference (commit SHA, tag, or branch) to checkout. For remote repositories, this determines which version to clone. For local repositories, this will checkout the specified ref. Defaults to `None`.
+*   `cache_ttl_hours` (Optional[float]): **New in vNEXT.** When cloning a remote repository, Kit stores the clone under `tmp/kit-repo-cache` (or your custom `cache_dir`).  On the *first* clone in each Python process Kit will delete any cached repo directory whose **modification time** is older than this many hours before continuing.  Pass `None` (default) or `0` to disable the cleanup.  You can also set the global environment variable `KIT_TMP_REPO_TTL_HOURS` to apply the policy process-wide without changing code.
 
 <Aside type="tip">
 **Automatic GitHub Token Pickup**
@@ -434,3 +436,23 @@ context_blob = assembler.format_context()
 * `ContextAssembler`: Ready-to-use assembler instance.
 
 ## `repository.get_summarizer()`
+
+### Automatic cleanup of the tmp repo cache
+
+When you work with remote URLs Kit tries to be fast by keeping a shallow clone on disk (default location: `/tmp/kit-repo-cache`).  Over time those can add up, especially in containerised environments.  With `cache_ttl_hours` (or the `KIT_TMP_REPO_TTL_HOURS` env-var) you can make Kit self-purge old clones:
+
+```python
+# Purge anything older than 2 hours, then clone
+repo = Repository(
+    "https://github.com/owner/repo",
+    cache_ttl_hours=2,
+)
+```
+
+**When does the purge run?**
+
+* The very first time `_clone_github_repo` is executed in a Python process (i.e., when the first remote repo is opened).
+* A light-weight helper walks the top-level folders inside the cache directory and removes those whose directory `mtime` is older than the TTL.
+* The helper is wrapped in `functools.lru_cache(maxsize=1)`, so subsequent clones in the same process don't repeat the walk.
+
+If you never set a TTL Kit keeps the previous behavior (clones live until the OS or you remove them).

--- a/src/kit/cli.py
+++ b/src/kit/cli.py
@@ -324,7 +324,7 @@ def file_content(
                 typer.echo(header)
                 typer.echo(text)
     except FileNotFoundError as e:
-        # Preserve previous behaviour for single file to satisfy existing expectations
+        # Preserve previous behavior for single file to satisfy existing expectations
         if len(file_paths) == 1:
             typer.secho(f"Error: File not found: {file_paths[0]}", fg=typer.colors.RED)
         else:

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -6,6 +6,9 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, overload
+from functools import lru_cache
+import time
+import shutil
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor
@@ -33,10 +36,26 @@ class Repository:
         github_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
         ref: Optional[str] = None,
+        *,
+        cache_ttl_hours: Optional[float] = None,
     ) -> None:
         # Auto-pickup GitHub token from environment if not provided
         if github_token is None:
             github_token = os.getenv("KIT_GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN")
+
+        # ------------------------------------------------------------------
+        # Cache-related settings
+        # ------------------------------------------------------------------
+        # Allow users to override TTL via explicit kwarg or env var.  ``None``
+        # means "do not auto-purge" (preserves previous behaviour).
+        if cache_ttl_hours is None:
+            ttl_env = os.getenv("KIT_TMP_REPO_TTL_HOURS")
+            try:
+                cache_ttl_hours = float(ttl_env) if ttl_env is not None else None
+            except ValueError:
+                cache_ttl_hours = None  # fall back silently on parse error
+
+        self.cache_ttl_hours: Optional[float] = cache_ttl_hours
 
         self.ref = ref  # Store the requested ref
         if path_or_url.startswith("http://") or path_or_url.startswith("https://"):  # Remote repo
@@ -170,7 +189,11 @@ class Repository:
         return f"<Repository path='{path_info}'{ref_info}, files: {file_count}>"
 
     def _clone_github_repo(
-        self, url: str, token: Optional[str], cache_dir: Optional[str], ref: Optional[str] = None
+        self,
+        url: str,
+        token: Optional[str],
+        cache_dir: Optional[str],
+        ref: Optional[str] = None,
     ) -> Path:
         from urllib.parse import urlparse
 
@@ -181,6 +204,9 @@ class Repository:
 
         cache_root = Path(cache_dir or tempfile.gettempdir()) / "kit-repo-cache"
         cache_root.mkdir(parents=True, exist_ok=True)
+
+        # One-time (per process) cleanup of stale cache entries.
+        self._perform_cache_cleanup(str(cache_root), self.cache_ttl_hours)
 
         repo_path = cache_root / repo_name
         if repo_path.exists() and (repo_path / ".git").exists():
@@ -772,3 +798,36 @@ class Repository:
         """Finalize analysis and save incremental cache."""
         if self._incremental_analyzer is not None:
             self.incremental_analyzer.finalize()
+
+    # ------------------------------------------------------------------
+    # Cache maintenance helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _perform_cache_cleanup(cache_root_str: str, ttl_hours: Optional[float]) -> None:
+        """Delete cached repos older than *ttl_hours*.
+
+        This function is wrapped in ``lru_cache`` so the directory walk runs
+        only once per Python process (for each unique *(path, ttl)* tuple).
+        Passing ``ttl_hours`` as *None* disables cleanup entirely.
+        """
+
+        if ttl_hours is None:
+            return  # Feature disabled; keep prior behaviour
+
+        try:
+            cutoff = time.time() - ttl_hours * 3600
+        except Exception:
+            return  # Defensive: invalid ttl
+
+        cache_root = Path(cache_root_str)
+
+        for repo_dir in cache_root.iterdir():
+            # Each sub-dir is a separate cloned repo
+            try:
+                if repo_dir.stat().st_mtime < cutoff:
+                    shutil.rmtree(repo_dir)
+            except Exception:
+                # Suppress all errors – we don't want cleanup failures to block cloning
+                continue

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
+import time
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, overload
-from functools import lru_cache
-import time
-import shutil
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor
@@ -54,9 +54,7 @@ class Repository:
                 cache_ttl_hours = float(ttl_env) if ttl_env is not None else None
             except ValueError:
                 # Provide debug info to help users troubleshoot misconfiguration
-                logger.debug(
-                    "Invalid value for KIT_TMP_REPO_TTL_HOURS=%r – falling back to no TTL", ttl_env
-                )
+                logger.debug("Invalid value for KIT_TMP_REPO_TTL_HOURS=%r - falling back to no TTL", ttl_env)
                 cache_ttl_hours = None  # fall back silently on parse error
 
         self.cache_ttl_hours: Optional[float] = cache_ttl_hours

--- a/tests/test_cache_cleanup.py
+++ b/tests/test_cache_cleanup.py
@@ -1,0 +1,62 @@
+import logging
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kit.repository import Repository
+
+
+def _make_repo_dir(root: Path, name: str, mtime_offset_hours: float = 0.0) -> Path:
+    """Helper to create a dummy repo directory with an adjusted *mtime*."""
+    repo_dir = root / name
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    if mtime_offset_hours:
+        ts = time.time() - mtime_offset_hours * 3600
+        os.utime(repo_dir, (ts, ts))
+    return repo_dir
+
+
+def test_performs_cache_cleanup(tmp_path: Path):
+    """Repositories older than *ttl* hours should be removed."""
+    cache_root = tmp_path / "kit-repo-cache"
+    cache_root.mkdir()
+
+    # Create one old repo (>2h) and one fresh repo (now)
+    old_repo = _make_repo_dir(cache_root, "old-repo", mtime_offset_hours=3)
+    fresh_repo = _make_repo_dir(cache_root, "fresh-repo")
+
+    # Reset the lru_cache to ensure the helper executes for this test
+    Repository._perform_cache_cleanup.cache_clear()
+
+    Repository._perform_cache_cleanup(str(cache_root), ttl_hours=2)
+
+    assert not old_repo.exists(), "Old repo should have been cleaned up"
+    assert fresh_repo.exists(), "Fresh repo should remain"
+
+
+def test_env_var_ttl_parsing(monkeypatch, tmp_path: Path):
+    """Environment variable should set default TTL when not explicitly provided."""
+    monkeypatch.setenv("KIT_TMP_REPO_TTL_HOURS", "1.5")
+
+    repo_dir = tmp_path / "dummy"
+    repo_dir.mkdir()
+
+    repo = Repository(str(repo_dir))  # Local path – no clone
+    assert repo.cache_ttl_hours == 1.5
+
+
+@pytest.mark.parametrize("val", ["", "not-a-number"])
+def test_env_var_ttl_invalid(monkeypatch, tmp_path: Path, val, caplog):
+    """Invalid env values should be ignored and logged at DEBUG level."""
+    monkeypatch.setenv("KIT_TMP_REPO_TTL_HOURS", val)
+    caplog.set_level(logging.DEBUG)
+
+    repo_dir = tmp_path / "dummy2"
+    repo_dir.mkdir()
+    repo = Repository(str(repo_dir))
+
+    assert repo.cache_ttl_hours is None
+    # Confirm a debug log entry was produced (optional but helpful)
+    assert any("Invalid value for KIT_TMP_REPO_TTL_HOURS" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION


<!-- AI SUMMARY START -->
## What This PR Does
This PR adds cache control functionality to the Repository class, allowing automatic cleanup of temporary repository clones. It introduces a configurable TTL (time-to-live) mechanism that removes cached repository directories older than a specified number of hours.

## Key Changes
- Added `cache_ttl_hours` parameter to Repository constructor for configurable cache cleanup
- Implemented `_perform_cache_cleanup()` method with LRU caching to remove stale repository clones
- Added support for `KIT_TMP_REPO_TTL_HOURS` environment variable as a global setting
- Updated documentation to explain the new cache control features and usage patterns
- Cache cleanup runs once per Python process when the first remote repository is accessed

## Impact
- **Areas affected**: Repository initialization, remote repository cloning, and cache management
- **Benefits**: Prevents disk space accumulation from cached clones, especially useful in containerized environments
- **Risks**: Minimal - feature is opt-in with sensible defaults, maintains backward compatibility when TTL is not set

*Generated by [kit](https://github.com/cased/kit) v1.1.0 • Model: claude-sonnet-4-20250514*
<!-- AI SUMMARY END -->