### PR TITLE
Make tiktoken dep optional in summaries.py

### DIFF
--- a/src/kit/summaries.py
+++ b/src/kit/summaries.py
@@ -5,7 +5,10 @@ import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union, runtime_checkable
 
-import tiktoken
+try:
+    import tiktoken
+except ImportError:
+    tiktoken = None
 
 
 # Define a Protocol for LLM clients to help with type checking
@@ -167,6 +170,9 @@ class Summarizer:
             encoding = tiktoken.encoding_for_model(model_name)
             self._tokenizer_cache[model_name] = encoding
             return encoding
+        except NameError:
+            logger.warning("tiktoken not available, token count will be approximate (char count).")
+            return None
         except KeyError:
             try:
                 # Fallback for models not directly in tiktoken.model.MODEL_TO_ENCODING


### PR DESCRIPTION
Heya! Love this lib and what you're working on. 

I noticed you're trying to handle cases where folks don't install LLM deps / uninstall them (I'm one of them, trying to slim down a docker build image).

Importing kit as-is raises an ImportError since tiktoken is a top-level import not wrapped in a try/except. 