### PR TITLE
Dedupe when multiple query patterns match

### DIFF
--- a/src/kit/summaries.py
+++ b/src/kit/summaries.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union, runtime_checkable
 
-tiktoken: Optional[Any]  # noqa: ANN401, PGH003
+tiktoken: Optional[Any]
 
 try:
     import tiktoken
@@ -171,9 +171,7 @@ class Summarizer:
         try:
             # If tiktoken is not available, exit early with None
             if tiktoken is None:
-                logger.warning(
-                    "tiktoken not available, token count will be approximate (char count)."
-                )
+                logger.warning("tiktoken not available, token count will be approximate (char count).")
                 return None
 
             # At this point, mypy knows `tiktoken` is not None, but we still cast for clarity

--- a/tests/test_tsx_duplicate_symbols.py
+++ b/tests/test_tsx_duplicate_symbols.py
@@ -1,0 +1,35 @@
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+
+def test_tsx_duplicate_symbols():
+    """Ensure TSX (using TypeScript fallback queries) does not return duplicate symbols."""
+    code = """
+import React from 'react';
+
+export interface Props {
+  title: string;
+}
+
+export class Header extends React.Component<Props> {
+  render() {
+    return <h1>{this.props.title}</h1>;
+  }
+}
+        """
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".tsx", code)
+
+    def _key(sym: dict[str, object]):
+        return (sym.get("name"), sym.get("type"), sym.get("start_line"), sym.get("end_line"))
+
+    keys = [_key(s) for s in symbols]
+    assert len(keys) == len(set(keys)), "Duplicate symbols detected for TSX"
+
+    # Ensure interface and class present (methods may also be captured)
+    names = {s["name"] for s in symbols}
+    assert {"Props", "Header"}.issubset(names)
+
+    # Expect interface + class + method (render)
+    names = {s["name"] for s in symbols}
+    assert "Props" in names
+    assert "Header" in names

--- a/tests/test_typescript_duplicate_symbols.py
+++ b/tests/test_typescript_duplicate_symbols.py
@@ -1,0 +1,34 @@
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+
+def test_typescript_duplicate_symbols():
+    """Ensure that exported TypeScript constructs are not duplicated in symbol extraction."""
+    code = """
+export class MyClass {
+  public value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+}
+
+export interface MyInterface {
+  id: string;
+  name: string;
+}
+        """
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+
+    # Build a uniqueness key identical to the deduplication logic
+    def _key(sym: dict[str, object]):
+        return (sym.get("name"), sym.get("type"), sym.get("start_line"), sym.get("end_line"))
+
+    keys = [_key(s) for s in symbols]
+
+    # Assert no duplicates
+    assert len(keys) == len(set(keys)), "Duplicate symbols should have been removed by extractor-dedup logic"
+
+    # Ensure the key symbols are present; we may also have methods etc.
+    names = {s["name"] for s in symbols}
+    assert {"MyClass", "MyInterface"}.issubset(names)


### PR DESCRIPTION


<!-- AI SUMMARY START -->
## What This PR Does
This PR fixes duplicate symbol extraction in TypeScript and TSX files that occurs when multiple Tree-sitter query patterns match the same code construct (e.g., both generic class and exported class patterns). It adds deduplication logic to remove symbols with identical names, types, and line positions.

## Key Changes
- Added deduplication logic in `tree_sitter_symbol_extractor.py` that removes symbols with matching name, type, start_line, and end_line
- Created comprehensive tests for both TypeScript and TSX files to verify duplicate removal
- Added debug logging to track when duplicates are found and removed
- Minor code formatting cleanup in `summaries.py` (unrelated linting fixes)

## Impact
- **Areas affected**: Symbol extraction for TypeScript/TSX files, test coverage
- **Benefits**: Cleaner symbol extraction results, eliminates redundant symbols in code analysis
- **Low risk**: Only affects the final filtering step of symbol extraction, preserving all functionality while improving output quality

*Generated by [kit](https://github.com/cased/kit) v1.2.2 • Model: claude-sonnet-4-20250514*
<!-- AI SUMMARY END -->