### PR TITLE
Additional tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cased-kit"
-version = "1.7.1"
+version = "1.7.2"
 description = "A modular toolkit for LLM-powered codebase understanding."
 authors = [
     { name = "Cased", email = "ted@cased.com" }

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -3,7 +3,7 @@ A modular toolkit for LLM-powered codebase understanding.
 """
 
 __author__ = "cased"
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -357,9 +357,7 @@ class TreeSitterSymbolExtractor:
             tree = parser.parse(bytes(source_code, "utf8"))
             root = tree.root_node
 
-            # Tree-sitter Python bindings changed in 0.23 – the `Query.matches` API was removed
-            # in favour of `Query.captures`. To maintain compatibility with both the old (<0.23)
-            # and new (>=0.23) versions we fall back to `captures` when `matches` does not exist.
+            # tree-sitter compatibility
             if hasattr(query, "matches"):
                 raw_matches = query.matches(root)  # type: ignore[attr-defined]
                 logger.debug(f"[EXTRACT] Found {len(raw_matches)} matches via Query.matches().")

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -357,12 +357,26 @@ class TreeSitterSymbolExtractor:
             tree = parser.parse(bytes(source_code, "utf8"))
             root = tree.root_node
 
-            matches = query.matches(root)
-            logger.debug(f"[EXTRACT] Found {len(matches)} matches.")
+            # Tree-sitter Python bindings changed in 0.23 – the `Query.matches` API was removed
+            # in favour of `Query.captures`. To maintain compatibility with both the old (<0.23)
+            # and new (>=0.23) versions we fall back to `captures` when `matches` does not exist.
+            if hasattr(query, "matches"):
+                raw_matches = query.matches(root)  # type: ignore[attr-defined]
+                logger.debug(f"[EXTRACT] Found {len(raw_matches)} matches via Query.matches().")
+                # Convert to unified (pattern_index, captures) structure expected below
+                match_tuples = list(raw_matches)  # already in correct format
+            else:
+                # Newer API – build a single pseudo-match dictionary grouping all captures
+                captures_dict: Dict[str, List[Any]] = {}
+                for capture_name, node in query.captures(root):  # type: ignore[attr-defined]
+                    captures_dict.setdefault(capture_name, []).append(node)
+                match_tuples = [(0, captures_dict)]
+                logger.debug(
+                    f"[EXTRACT] Found {sum(len(v) for v in captures_dict.values())} captures via Query.captures()."
+                )
 
-            # matches is List[Tuple[int, Dict[str, Node]]]
-            # Each tuple is (pattern_index, {capture_name: Node})
-            for pattern_index, captures in matches:
+            # Now process matches
+            for pattern_index, captures in match_tuples:
                 logger.debug(f"[MATCH pattern={pattern_index}] Processing match with captures: {list(captures.keys())}")
 
                 # Determine symbol name: prefer @name, fallback to @type for blocks like terraform/locals

--- a/tests/test_tree_sitter_query_compat.py
+++ b/tests/test_tree_sitter_query_compat.py
@@ -1,0 +1,62 @@
+import types
+
+import pytest
+
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+
+class _DummyNode:
+    def __init__(self, text="dummy"):
+        # tree-sitter Node objects expose a ``text`` bytes property
+        self.text = text.encode()
+        # Some grammar queries access ``type`` – keep minimal attr
+        self.type = "identifier"
+        # Minimal positional info expected by extractor
+        self.start_point = (0, 0)
+        self.end_point = (0, len(text))
+        self.start_byte = 0
+        self.end_byte = len(text)
+
+
+class _DummyParser:
+    """Bare-minimum parser that returns an object with ``root_node`` attr."""
+
+    class _DummyTree:
+        def __init__(self):
+            self.root_node = None  # We never inspect it in the stub
+
+    def parse(self, _bytes: bytes):  # noqa: D401 – simple stub
+        return self._DummyTree()
+
+
+class _FakeQueryCapturesOnly:
+    """Simulates tree_sitter.Query when the legacy ``matches`` API is missing."""
+
+    def captures(self, _root):
+        # Return a minimal sequence of (capture_name, node) tuples
+        return [("name", _DummyNode())]
+
+
+@pytest.fixture(autouse=True)
+def _patch_tree_sitter(monkeypatch):
+    """Monkey-patch the extractor to return our dummy query / parser."""
+
+    monkeypatch.setattr(
+        TreeSitterSymbolExtractor,
+        "get_query",
+        lambda _ext: _FakeQueryCapturesOnly(),
+    )
+    monkeypatch.setattr(
+        TreeSitterSymbolExtractor,
+        "get_parser",
+        lambda _ext: _DummyParser(),
+    )
+
+
+def test_extract_symbols_fallback_to_captures():
+    """`extract_symbols` should work when `Query.matches` is unavailable (>=0.23)."""
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".py", "print('hi')\n")
+
+    assert symbols, "Expected at least one symbol when using captures-only Query"
+    assert symbols[0]["name"] == "dummy" 


### PR DESCRIPTION
This pull request introduces a version update for the `cased-kit` package, adds compatibility for newer versions of the `tree-sitter` library, and includes a new test to ensure the compatibility changes work as expected. Below are the most important changes grouped by theme:

### Version Update:
* Updated the version of `cased-kit` from `1.7.1` to `1.7.2` in both `pyproject.toml` and `src/kit/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-c9131a50757fe4429bed833db95904d001bff1491ffbb4de4d552d9e8ee799a7L6-R6)

### Compatibility Enhancements:
* Modified `extract_symbols` in `tree_sitter_symbol_extractor.py` to support both legacy `Query.matches` and newer `Query.captures` APIs from `tree-sitter`. This ensures compatibility with `tree-sitter` versions >= 0.23.

### Testing:
* Added a new test file `tests/test_tree_sitter_query_compat.py` to validate the fallback behavior of `extract_symbols` when the `Query.matches` API is unavailable. This includes mock implementations of `tree-sitter` components and a test case for the newer `Query.captures` API.