### PR TITLE
Fix tree-sitter compat

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runcased/kit",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "TypeScript wrapper for Cased Kit CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -10,6 +10,35 @@ All notable changes to Kit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2025-01-14
+
+### Bug Fixes
+
+- **Tree-sitter API Compatibility**: Fixed AttributeError with `Query.captures` method across different tree-sitter versions
+  - Added robust fallback mechanism between `matches()` and `captures()` APIs
+  - Improved error handling for various tree-sitter API surfaces
+  - Ensures compatibility with tree-sitter >= 0.23.2
+
+- **Test Isolation**: Fixed cache isolation issue in `test_helicone_api_integration`
+  - Added proper LRU cache clearing for test isolation
+  - Prevents test failures due to cached pricing data
+
+### New Features
+
+- **Extended OpenAI Model Support**
+  - Added support for GPT-5 models: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
+  - Added support for O3 series models: `o3`, `o3-mini`, `o3-medium`
+  - Enhanced model detection patterns for future OpenAI model families
+
+### Testing
+
+- **Comprehensive Tree-sitter Compatibility Tests**
+  - Added test suite covering different tree-sitter API versions
+  - Tests for both `matches()` and `captures()` API methods
+  - Edge case handling for missing or non-functional APIs
+
+---
+
 ## [1.9.0] - 2025-08-19
 
 ### Major Features

--- a/docs/src/content/docs/pr-reviewer/configuration.mdx
+++ b/docs/src/content/docs/pr-reviewer/configuration.mdx
@@ -63,10 +63,18 @@ gpt-4.1-nano             # Ultra-budget: ~$0.0015-0.004
 gpt-4.1-mini             # Budget-friendly: ~$0.005-0.015
 gpt-4o-mini              # Newer mini model
 
-# Standard options  
+# Standard options
 gpt-4.1                  # Good balance: ~$0.02-0.10
 gpt-4o                   # Latest GPT-4 model
 gpt-4-turbo              # Fast GPT-4 variant
+
+# Latest models (GPT-5 and O3 series)
+gpt-5                    # Latest GPT-5 model
+gpt-5-mini               # Budget GPT-5 variant
+gpt-5-nano               # Ultra-budget GPT-5
+o3                       # O3 reasoning model
+o3-mini                  # Budget O3 variant
+o3-medium                # Balanced O3 model
 ```
 
 ### Anthropic Claude

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cased-kit"
-version = "1.9.1"
+version = "1.9.2"
 description = "A modular toolkit for LLM-powered codebase understanding."
 authors = [
     { name = "Cased", email = "ted@cased.com" }

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -3,7 +3,7 @@ A modular toolkit for LLM-powered codebase understanding.
 """
 
 __author__ = "cased"
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor

--- a/src/kit/pr_review/config.py
+++ b/src/kit/pr_review/config.py
@@ -49,8 +49,13 @@ def _detect_provider_from_model(model_name: str) -> Optional[LLMProvider]:
             stripped_model = stripped_model[len(prefix) :]
             break
 
-    # OpenAI model patterns
-    openai_patterns = ["gpt-", "o1-", "text-davinci", "text-curie", "text-babbage", "text-ada"]
+    # OpenAI model patterns (includes GPT-5 mini/nano and O3 models)
+    # Check exact matches first
+    if stripped_model == "o3":
+        return LLMProvider.OPENAI
+
+    # Then check prefix/substring patterns
+    openai_patterns = ["gpt-", "o1-", "o3-", "text-davinci", "text-curie", "text-babbage", "text-ada"]
     if any(pattern in stripped_model for pattern in openai_patterns):
         return LLMProvider.OPENAI
 
@@ -243,7 +248,7 @@ class ReviewConfig:
                 config_api_key = None  # Treat placeholder as missing
             api_key = config_api_key or os.getenv("KIT_ANTHROPIC_TOKEN") or os.getenv("ANTHROPIC_API_KEY")
         elif provider == LLMProvider.GOOGLE:
-            default_model = "gemini-2.5-flash"  # Updated to latest model
+            default_model = "gemini-2.5-flash"
             api_key_env = "KIT_GOOGLE_API_KEY or GOOGLE_API_KEY"
             config_api_key = llm_data.get("api_key")
             if _is_placeholder_token(config_api_key):

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -31,7 +31,13 @@ def test_detect_provider_from_model():
     assert _detect_provider_from_model("gpt-4o") == LLMProvider.OPENAI
     assert _detect_provider_from_model("gpt-4.1-nano") == LLMProvider.OPENAI
     assert _detect_provider_from_model("gpt-3.5-turbo") == LLMProvider.OPENAI
+    assert _detect_provider_from_model("gpt-5") == LLMProvider.OPENAI
+    assert _detect_provider_from_model("gpt-5-mini") == LLMProvider.OPENAI
+    assert _detect_provider_from_model("gpt-5-nano") == LLMProvider.OPENAI
     assert _detect_provider_from_model("o1-preview") == LLMProvider.OPENAI
+    assert _detect_provider_from_model("o3") == LLMProvider.OPENAI
+    assert _detect_provider_from_model("o3-mini") == LLMProvider.OPENAI
+    assert _detect_provider_from_model("o3-medium") == LLMProvider.OPENAI
     assert _detect_provider_from_model("text-davinci-003") == LLMProvider.OPENAI
 
     # Anthropic models

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1422,6 +1422,9 @@ def test_helicone_api_integration():
 
     from kit.pr_review.cost_tracker import CostTracker
 
+    # Clear the cache first to ensure test isolation
+    CostTracker._fetch_pricing_with_cache.cache_clear()
+
     # Mock successful API response
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -1451,6 +1454,9 @@ def test_helicone_api_integration():
         tracker.track_llm_usage(LLMProvider.OPENAI, "gpt-4o", 1000, 1000)
         expected_cost = (1000 / 1_000_000) * 5.0 + (1000 / 1_000_000) * 15.0
         assert abs(tracker.breakdown.llm_cost_usd - expected_cost) < 0.0001
+
+    # Clear cache again to avoid affecting other tests
+    CostTracker._fetch_pricing_with_cache.cache_clear()
 
 
 def test_helicone_api_fallback():

--- a/tests/test_tree_sitter_compatibility.py
+++ b/tests/test_tree_sitter_compatibility.py
@@ -1,0 +1,169 @@
+"""Test tree-sitter API compatibility handling."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+
+class TestTreeSitterCompatibility:
+    """Test that symbol extraction handles different tree-sitter API versions."""
+
+    def test_matches_api_success(self):
+        """Test successful extraction using matches() API."""
+        code = "function test() { return 42; }"
+
+        # Mock query with matches() method
+        mock_query = Mock()
+        mock_query.matches = Mock(return_value=[
+            (0, {"name": [Mock(text=b"test", start_point=(0, 9), end_point=(0, 13), start_byte=9, end_byte=13)],
+                 "definition.function": [Mock(text=b"function test() { return 42; }",
+                                             start_point=(0, 0), end_point=(0, 30),
+                                             start_byte=0, end_byte=30)]})
+        ])
+
+        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+                mock_tree = Mock()
+                mock_tree.root_node = Mock()
+                mock_parser.return_value.parse.return_value = mock_tree
+
+                symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+
+                assert len(symbols) == 1
+                assert symbols[0]["name"] == "test"
+                assert symbols[0]["type"] == "function"
+                mock_query.matches.assert_called_once()
+
+    def test_captures_api_fallback(self):
+        """Test fallback to captures() API when matches() doesn't exist."""
+        code = "interface User { id: number; }"
+
+        # Mock query without matches() but with captures()
+        mock_query = Mock(spec=['captures', 'capture_count'])
+        mock_query.captures = Mock(return_value=[
+            ("name", Mock(text=b"User", start_point=(0, 10), end_point=(0, 14), start_byte=10, end_byte=14)),
+            ("definition.interface", Mock(text=b"interface User { id: number; }",
+                                        start_point=(0, 0), end_point=(0, 30),
+                                        start_byte=0, end_byte=30))
+        ])
+
+        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+                mock_tree = Mock()
+                mock_tree.root_node = Mock()
+                mock_parser.return_value.parse.return_value = mock_tree
+
+                symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+
+                assert len(symbols) == 1
+                assert symbols[0]["name"] == "User"
+                assert symbols[0]["type"] == "interface"
+                mock_query.captures.assert_called_once()
+
+    def test_matches_api_attribute_error(self):
+        """Test handling when matches() exists but throws AttributeError."""
+        code = "class Test {}"
+
+        # Mock query where matches() exists but fails
+        mock_query = Mock()
+        mock_query.matches = Mock(side_effect=AttributeError("'Query' object has no attribute 'matches'"))
+        mock_query.captures = Mock(return_value=[
+            ("name", Mock(text=b"Test", start_point=(0, 6), end_point=(0, 10), start_byte=6, end_byte=10)),
+            ("definition.class", Mock(text=b"class Test {}",
+                                    start_point=(0, 0), end_point=(0, 13),
+                                    start_byte=0, end_byte=13))
+        ])
+
+        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+                mock_tree = Mock()
+                mock_tree.root_node = Mock()
+                mock_parser.return_value.parse.return_value = mock_tree
+
+                symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+
+                assert len(symbols) == 1
+                assert symbols[0]["name"] == "Test"
+                assert symbols[0]["type"] == "class"
+                mock_query.matches.assert_called_once()
+                mock_query.captures.assert_called_once()
+
+    def test_no_compatible_api(self):
+        """Test handling when neither matches() nor captures() work."""
+        code = "const x = 42;"
+
+        # Mock query where both APIs fail
+        mock_query = Mock()
+        mock_query.matches = Mock(side_effect=AttributeError("No matches"))
+        mock_query.captures = Mock(side_effect=AttributeError("No captures"))
+
+        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+                mock_tree = Mock()
+                mock_tree.root_node = Mock()
+                mock_parser.return_value.parse.return_value = mock_tree
+
+                symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+
+                assert symbols == []
+                mock_query.matches.assert_called_once()
+                mock_query.captures.assert_called_once()
+
+    def test_query_object_without_methods(self):
+        """Test handling when query object exists but has no methods."""
+        code = "function test() {}"
+
+        # Mock query with no matches or captures methods
+        mock_query = Mock(spec=[])  # Empty spec means no methods
+
+        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+                mock_tree = Mock()
+                mock_tree.root_node = Mock()
+                mock_parser.return_value.parse.return_value = mock_tree
+
+                symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+
+                assert symbols == []
+
+    def test_real_typescript_extraction(self):
+        """Test with real TypeScript code to ensure compatibility."""
+        typescript_code = """
+interface User {
+    id: number;
+    name: string;
+}
+
+class UserService {
+    private users: User[] = [];
+
+    addUser(user: User): void {
+        this.users.push(user);
+    }
+
+    getUser(id: number): User | undefined {
+        return this.users.find(u => u.id === id);
+    }
+}
+
+export function greetUser(name: string): string {
+    return `Hello, ${name}!`;
+}
+"""
+
+        # This should work with the actual implementation
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", typescript_code)
+
+        # Verify we got the expected symbols
+        symbol_names = [s["name"] for s in symbols]
+        assert "User" in symbol_names
+        assert "UserService" in symbol_names
+        assert "addUser" in symbol_names
+        assert "getUser" in symbol_names
+        assert "greetUser" in symbol_names
+
+        # Verify types are correct
+        symbol_map = {s["name"]: s["type"] for s in symbols}
+        assert symbol_map.get("User") == "interface"
+        assert symbol_map.get("UserService") == "class"
+        assert symbol_map.get("greetUser") == "function"


### PR DESCRIPTION
Should resolve https://github.com/cased/kit/issues/132. 

Improves the compatibility and robustness of the symbol extraction logic in `TreeSitterSymbolExtractor` when working with different versions of the tree-sitter library. It introduces error handling and fallback mechanisms for the `matches()` and `captures()` APIs, ensuring extraction works across tree-sitter versions. Additionally, it adds a suite of tests to verify behavior under various scenarios and edge cases.

Compatibility improvements:

* Enhanced `extract_symbols` to robustly try both `matches()` and `captures()` APIs with error handling, ensuring compatibility with both older and newer tree-sitter versions and logging warnings when neither API is available.

Testing and verification:

* Added `tests/test_tree_sitter_compatibility.py` to thoroughly test symbol extraction logic, including cases for successful extraction via `matches()`, fallback to `captures()`, error handling when APIs fail, and extraction from real TypeScript code.