### PR TITLE
Fix tree-sitter compat layer

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runcased/kit",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "TypeScript wrapper for Cased Kit CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cased-kit"
-version = "1.9.2"
+version = "1.9.3"
 description = "A modular toolkit for LLM-powered codebase understanding."
 authors = [
     { name = "Cased", email = "ted@cased.com" }
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 dependencies = [
+    "tree-sitter>=0.25.1",
     "tree-sitter-language-pack>=0.7.2",
     "pathspec>=0.11.1",
     "numpy>=1.25",

--- a/src/kit/__init__.py
+++ b/src/kit/__init__.py
@@ -3,7 +3,7 @@ A modular toolkit for LLM-powered codebase understanding.
 """
 
 __author__ = "cased"
-__version__ = "1.9.2"
+__version__ = "1.9.3"
 
 from .code_searcher import CodeSearcher
 from .context_extractor import ContextExtractor

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -446,7 +446,7 @@ class TreeSitterSymbolExtractor:
 
                 # Now extract symbol name as before
                 symbol_name = (
-                    actual_name_node.text.decode() if hasattr(actual_name_node, "text") else str(actual_name_node)
+                    actual_name_node.text.decode() if hasattr(actual_name_node, "text") and actual_name_node.text else str(actual_name_node)
                 )
                 # HCL: Strip quotes from string literals
                 if ext == ".tf" and hasattr(actual_name_node, "type") and actual_name_node.type == "string_lit":
@@ -465,8 +465,8 @@ class TreeSitterSymbolExtractor:
                         type_node = captures.get("type")
                         if type_node:
                             if isinstance(type_node, list):
-                                type_node = type_node[0] if type_node else None
-                            if type_node and hasattr(type_node, "text"):
+                                type_node = type_node[0] if len(type_node) > 0 else None
+                            if type_node and hasattr(type_node, "text") and type_node.text:
                                 type_name = type_node.text.decode()
                                 if hasattr(type_node, "type") and type_node.type == "string_lit":
                                     if len(type_name) >= 2 and type_name.startswith('"') and type_name.endswith('"'):

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -4,6 +4,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, cast
 
+import tree_sitter
 from tree_sitter_language_pack import get_language, get_parser
 
 # Set up module-level logger
@@ -287,13 +288,20 @@ class TreeSitterSymbolExtractor:
                 return None
 
             language = get_language(cast(Any, lang_name))  # type: ignore[arg-type]
-            query = language.query(combined_query_content)
+            # Use the new tree_sitter.Query constructor instead of deprecated language.query()
+            query = tree_sitter.Query(language, combined_query_content)
             cls._queries[ext] = query
             logger.debug(f"get_query: Query loaded successfully for ext {ext}")
             return query
 
+        except tree_sitter.QueryError as e:
+            # Specific query syntax error
+            logger.error(f"get_query: Query syntax error for {ext} ({lang_name}): {e}")
+            logger.error(f"Query content length: {len(combined_query_content)} chars")
+            logger.error(traceback.format_exc())
+            return None
         except Exception as e:
-            logger.error(f"get_query: Query compile error for ext {ext}: {e}")
+            logger.error(f"get_query: Unexpected error loading query for {ext}: {e}")
             logger.error(traceback.format_exc())
             return None
 
@@ -360,39 +368,54 @@ class TreeSitterSymbolExtractor:
             root = tree.root_node
 
             # tree-sitter compatibility - try different APIs based on what's available
-            # tree-sitter >= 0.23.2 may have different API surfaces depending on version
-            # and how it was compiled. We try both matches() and captures() with proper
-            # error handling to ensure compatibility across versions.
+            # tree-sitter >= 0.25.1 uses QueryCursor with the query as a parameter
             match_tuples = []
+            api_worked = False
 
-            # First try the matches() API (older tree-sitter versions)
-            if hasattr(query, "matches") and callable(getattr(query, "matches", None)):
-                try:
-                    raw_matches = query.matches(root)  # type: ignore[attr-defined]
-                    match_tuples = list(raw_matches)  # already in correct format
-                    logger.debug(f"[EXTRACT] Found {len(match_tuples)} matches via Query.matches().")
-                except (AttributeError, TypeError) as e:
-                    logger.debug(f"[EXTRACT] matches() failed: {e}, trying captures()")
-                    match_tuples = []
+            # Try the new QueryCursor API (tree-sitter >= 0.25.1)
+            try:
+                cursor = tree_sitter.QueryCursor(query)
+                raw_matches = cursor.matches(root)
+                match_tuples = list(raw_matches)
+                api_worked = True  # API worked, even if no matches found
+                logger.debug(f"[EXTRACT] Found {len(match_tuples)} matches via QueryCursor.matches().")
+            except Exception as e:
+                # Log the actual error for debugging
+                logger.debug(f"[EXTRACT] QueryCursor API failed with {type(e).__name__}: {e}")
+                if not isinstance(e, (AttributeError, TypeError, NameError)):
+                    # If it's an unexpected error, log it as a warning
+                    logger.warning(f"[EXTRACT] Unexpected error with QueryCursor for {ext}: {e}")
 
-            # If matches() didn't work or doesn't exist, try captures() API
-            if not match_tuples and hasattr(query, "captures") and callable(getattr(query, "captures", None)):
-                try:
-                    # Newer API – build a single pseudo-match dictionary grouping all captures
-                    captures_dict: Dict[str, List[Any]] = {}
-                    captures_result = query.captures(root)  # type: ignore[attr-defined]
-                    for capture_name, node in captures_result:
-                        captures_dict.setdefault(capture_name, []).append(node)
-                    match_tuples = [(0, captures_dict)]
-                    logger.debug(
-                        f"[EXTRACT] Found {sum(len(v) for v in captures_dict.values())} captures via Query.captures()."
-                    )
-                except (AttributeError, TypeError) as e:
-                    logger.debug(f"[EXTRACT] captures() failed: {e}")
-                    match_tuples = []
+            # Fallback to older API only if the new API didn't work (not just if no matches)
+            if not api_worked:
+                # Try the matches() API directly on query (older tree-sitter versions)
+                if hasattr(query, "matches") and callable(getattr(query, "matches", None)):
+                    try:
+                        raw_matches = query.matches(root)  # type: ignore[attr-defined]
+                        match_tuples = list(raw_matches)  # already in correct format
+                        api_worked = True
+                        logger.debug(f"[EXTRACT] Found {len(match_tuples)} matches via Query.matches().")
+                    except (AttributeError, TypeError) as e:
+                        logger.debug(f"[EXTRACT] matches() failed: {e}, trying captures()")
 
-            # If neither API worked, log a warning and return empty
-            if not match_tuples:
+                # If matches() didn't work or doesn't exist, try captures() API
+                if not api_worked and hasattr(query, "captures") and callable(getattr(query, "captures", None)):
+                    try:
+                        # Older API – build a single pseudo-match dictionary grouping all captures
+                        captures_dict: Dict[str, List[Any]] = {}
+                        captures_result = query.captures(root)  # type: ignore[attr-defined]
+                        for capture_name, node in captures_result:
+                            captures_dict.setdefault(capture_name, []).append(node)
+                        match_tuples = [(0, captures_dict)]
+                        api_worked = True
+                        logger.debug(
+                            f"[EXTRACT] Found {sum(len(v) for v in captures_dict.values())} captures via Query.captures()."
+                        )
+                    except (AttributeError, TypeError) as e:
+                        logger.debug(f"[EXTRACT] captures() failed: {e}")
+
+            # If no API worked, log a warning and return empty
+            if not api_worked:
                 logger.warning(f"[EXTRACT] No compatible tree-sitter API found for extension {ext}")
                 return []
 

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -464,11 +464,11 @@ class TreeSitterSymbolExtractor:
                     if ext == ".tf" and symbol_type in ["resource", "data"]:
                         type_node = captures.get("type")
                         if type_node:
-                            if isinstance(type_node, list):
-                                type_node = type_node[0] if len(type_node) > 0 else None
-                            if type_node and hasattr(type_node, "text") and type_node.text:
-                                type_name = type_node.text.decode()
-                                if hasattr(type_node, "type") and type_node.type == "string_lit":
+                            # Extract the actual node from list if needed
+                            actual_type_node = type_node[0] if isinstance(type_node, list) and len(type_node) > 0 else type_node
+                            if actual_type_node and hasattr(actual_type_node, "text") and actual_type_node.text:
+                                type_name = actual_type_node.text.decode()
+                                if hasattr(actual_type_node, "type") and actual_type_node.type == "string_lit":
                                     if len(type_name) >= 2 and type_name.startswith('"') and type_name.endswith('"'):
                                         type_name = type_name[1:-1]
                                 symbol_name = f"{type_name}.{symbol_name}"

--- a/src/kit/vector_searcher.py
+++ b/src/kit/vector_searcher.py
@@ -141,9 +141,9 @@ class ChromaCloudBackend(VectorDBBackend):
                 "Chroma Cloud tenant not specified. Set CHROMA_TENANT environment variable "
                 "(check your Chroma Cloud dashboard for your tenant UUID) or pass tenant directly."
             )
-        
+
         # Validate tenant UUID format
-        uuid_pattern = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.IGNORECASE)
+        uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
         if not uuid_pattern.match(tenant):
             raise ValueError(
                 f"Invalid tenant format: '{tenant}'. "

--- a/tests/test_chroma_cloud.py
+++ b/tests/test_chroma_cloud.py
@@ -25,7 +25,12 @@ class TestChromaCloudBackend(unittest.TestCase):
 
     @patch("kit.vector_searcher.CloudClient")
     @patch.dict(
-        os.environ, {"CHROMA_API_KEY": "test-api-key", "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f", "CHROMA_DATABASE": "test-db"}
+        os.environ,
+        {
+            "CHROMA_API_KEY": "test-api-key",
+            "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f",
+            "CHROMA_DATABASE": "test-db",
+        },
     )
     def test_init_with_env_vars(self, mock_cloud_client):
         """Test initialization with environment variables."""
@@ -48,7 +53,10 @@ class TestChromaCloudBackend(unittest.TestCase):
         mock_cloud_client.return_value = mock_client_instance
 
         ChromaCloudBackend(
-            collection_name="my_collection", api_key="explicit-key", tenant="a1b2c3d4-e5f6-7890-abcd-ef1234567890", database="my-db"
+            collection_name="my_collection",
+            api_key="explicit-key",
+            tenant="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            database="my-db",
         )
 
         mock_cloud_client.assert_called_once_with(
@@ -60,14 +68,22 @@ class TestChromaCloudBackend(unittest.TestCase):
 
     def test_init_without_api_key_raises(self):
         """Test that initialization without API key raises ValueError."""
-        with patch.dict(os.environ, {"CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f", "CHROMA_DATABASE": "test-db"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f", "CHROMA_DATABASE": "test-db"},
+            clear=True,
+        ):
             with self.assertRaises(ValueError) as cm:
                 ChromaCloudBackend()
             self.assertIn("Chroma Cloud API key not found", str(cm.exception))
-    
+
     def test_init_with_invalid_tenant_uuid_raises(self):
         """Test that initialization with invalid tenant UUID raises ValueError."""
-        with patch.dict(os.environ, {"CHROMA_API_KEY": "test-key", "CHROMA_TENANT": "not-a-uuid", "CHROMA_DATABASE": "test-db"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"CHROMA_API_KEY": "test-key", "CHROMA_TENANT": "not-a-uuid", "CHROMA_DATABASE": "test-db"},
+            clear=True,
+        ):
             with self.assertRaises(ValueError) as cm:
                 ChromaCloudBackend()
             self.assertIn("Invalid tenant format", str(cm.exception))
@@ -76,7 +92,12 @@ class TestChromaCloudBackend(unittest.TestCase):
 
     @patch("kit.vector_searcher.CloudClient")
     @patch.dict(
-        os.environ, {"CHROMA_API_KEY": "test-api-key", "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f", "CHROMA_DATABASE": "test-db"}
+        os.environ,
+        {
+            "CHROMA_API_KEY": "test-api-key",
+            "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f",
+            "CHROMA_DATABASE": "test-db",
+        },
     )
     def test_add_embeddings(self, mock_cloud_client):
         """Test adding embeddings to cloud backend."""
@@ -96,7 +117,12 @@ class TestChromaCloudBackend(unittest.TestCase):
 
     @patch("kit.vector_searcher.CloudClient")
     @patch.dict(
-        os.environ, {"CHROMA_API_KEY": "test-api-key", "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f", "CHROMA_DATABASE": "test-db"}
+        os.environ,
+        {
+            "CHROMA_API_KEY": "test-api-key",
+            "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f",
+            "CHROMA_DATABASE": "test-db",
+        },
     )
     def test_query(self, mock_cloud_client):
         """Test querying the cloud backend."""
@@ -121,7 +147,12 @@ class TestChromaCloudBackend(unittest.TestCase):
 
     @patch("kit.vector_searcher.CloudClient")
     @patch.dict(
-        os.environ, {"CHROMA_API_KEY": "test-api-key", "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f", "CHROMA_DATABASE": "test-db"}
+        os.environ,
+        {
+            "CHROMA_API_KEY": "test-api-key",
+            "CHROMA_TENANT": "3893b771-b971-4f45-8e30-7aac7837ad7f",
+            "CHROMA_DATABASE": "test-db",
+        },
     )
     def test_delete(self, mock_cloud_client):
         """Test deleting vectors from cloud backend."""

--- a/tests/test_haskell_symbol_extraction.py
+++ b/tests/test_haskell_symbol_extraction.py
@@ -2,7 +2,6 @@ import pytest
 
 from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
 
-
 HS_SAMPLE = r"""
 module A.B where
 

--- a/tests/test_tree_sitter_api_compat.py
+++ b/tests/test_tree_sitter_api_compat.py
@@ -1,0 +1,130 @@
+"""Tests for tree-sitter API compatibility (0.25.1+ with QueryCursor)."""
+
+import pytest
+import tree_sitter
+from tree_sitter_language_pack import get_language, get_parser
+
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+
+def test_tree_sitter_version():
+    """Verify we're using tree-sitter >= 0.25.1."""
+    # tree-sitter 0.25.1 should have QueryCursor that requires query parameter
+    with pytest.raises(TypeError, match="missing required argument"):
+        tree_sitter.QueryCursor()
+
+
+def test_query_cursor_api():
+    """Test that the new QueryCursor API works correctly."""
+    parser = get_parser("python")
+    language = get_language("python")
+
+    code = """
+def hello():
+    return "world"
+
+class MyClass:
+    def method(self):
+        pass
+"""
+
+    tree = parser.parse(bytes(code, "utf8"))
+    root = tree.root_node
+
+    # Create a simple query
+    query_text = "(function_definition name: (identifier) @name)"
+    query = tree_sitter.Query(language, query_text)
+
+    # Test that QueryCursor with query works
+    cursor = tree_sitter.QueryCursor(query)
+    assert cursor is not None
+
+    # Test that matches() works
+    matches = cursor.matches(root)
+    assert isinstance(matches, list)
+    assert len(matches) == 2  # hello and method
+
+    # Verify match structure
+    for match_idx, match in enumerate(matches):
+        pattern_idx, captures = match
+        assert isinstance(pattern_idx, int)
+        assert isinstance(captures, dict)
+        assert "name" in captures
+        assert isinstance(captures["name"], list)
+        assert len(captures["name"]) > 0
+
+
+def test_extract_symbols_with_new_api():
+    """Test that TreeSitterSymbolExtractor works with the new API."""
+    python_code = """
+def foo():
+    pass
+
+class Bar:
+    def baz(self):
+        return 42
+"""
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".py", python_code)
+
+    assert len(symbols) == 3
+    symbol_names = {s["name"] for s in symbols}
+    assert symbol_names == {"foo", "Bar", "baz"}
+
+    symbol_types = {s["type"] for s in symbols}
+    assert "function" in symbol_types
+    assert "class" in symbol_types
+    assert "method" in symbol_types
+
+
+def test_extract_symbols_typescript():
+    """Test TypeScript symbol extraction with new API."""
+    ts_code = """
+interface User {
+    id: number;
+    name: string;
+}
+
+class UserService {
+    getUser(id: number): User {
+        return { id, name: "Test" };
+    }
+}
+
+export function processUser(user: User): void {
+    console.log(user.name);
+}
+"""
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", ts_code)
+
+    assert len(symbols) == 4
+    symbol_names = {s["name"] for s in symbols}
+    assert symbol_names == {"User", "UserService", "getUser", "processUser"}
+
+    # Verify types
+    for symbol in symbols:
+        if symbol["name"] == "User":
+            assert symbol["type"] == "interface"
+        elif symbol["name"] == "UserService":
+            assert symbol["type"] == "class"
+        elif symbol["name"] == "getUser":
+            assert symbol["type"] == "method"
+        elif symbol["name"] == "processUser":
+            assert symbol["type"] == "function"
+
+
+def test_multiple_languages():
+    """Test that multiple languages work with the new API."""
+    test_cases = [
+        (".go", 'func main() { fmt.Println("Hello") }', 1, {"main"}),
+        (".rs", "fn calculate(x: i32) -> i32 { x * 2 }", 1, {"calculate"}),
+        (".java", "public class Test { public void run() {} }", 2, {"Test", "run"}),
+        (".rb", 'def greeting\n  puts "hello"\nend', 1, {"greeting"}),
+    ]
+
+    for ext, code, expected_count, expected_names in test_cases:
+        symbols = TreeSitterSymbolExtractor.extract_symbols(ext, code)
+        assert len(symbols) == expected_count, f"Failed for {ext}"
+        symbol_names = {s["name"] for s in symbols}
+        assert symbol_names == expected_names, f"Failed for {ext}"

--- a/tests/test_tree_sitter_compatibility.py
+++ b/tests/test_tree_sitter_compatibility.py
@@ -1,7 +1,7 @@
 """Test tree-sitter API compatibility handling."""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
+
 from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
 
 
@@ -14,15 +14,28 @@ class TestTreeSitterCompatibility:
 
         # Mock query with matches() method
         mock_query = Mock()
-        mock_query.matches = Mock(return_value=[
-            (0, {"name": [Mock(text=b"test", start_point=(0, 9), end_point=(0, 13), start_byte=9, end_byte=13)],
-                 "definition.function": [Mock(text=b"function test() { return 42; }",
-                                             start_point=(0, 0), end_point=(0, 30),
-                                             start_byte=0, end_byte=30)]})
-        ])
+        mock_query.matches = Mock(
+            return_value=[
+                (
+                    0,
+                    {
+                        "name": [Mock(text=b"test", start_point=(0, 9), end_point=(0, 13), start_byte=9, end_byte=13)],
+                        "definition.function": [
+                            Mock(
+                                text=b"function test() { return 42; }",
+                                start_point=(0, 0),
+                                end_point=(0, 30),
+                                start_byte=0,
+                                end_byte=30,
+                            )
+                        ],
+                    },
+                )
+            ]
+        )
 
-        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
-            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+        with patch.object(TreeSitterSymbolExtractor, "get_query", return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, "get_parser") as mock_parser:
                 mock_tree = Mock()
                 mock_tree.root_node = Mock()
                 mock_parser.return_value.parse.return_value = mock_tree
@@ -39,16 +52,25 @@ class TestTreeSitterCompatibility:
         code = "interface User { id: number; }"
 
         # Mock query without matches() but with captures()
-        mock_query = Mock(spec=['captures', 'capture_count'])
-        mock_query.captures = Mock(return_value=[
-            ("name", Mock(text=b"User", start_point=(0, 10), end_point=(0, 14), start_byte=10, end_byte=14)),
-            ("definition.interface", Mock(text=b"interface User { id: number; }",
-                                        start_point=(0, 0), end_point=(0, 30),
-                                        start_byte=0, end_byte=30))
-        ])
+        mock_query = Mock(spec=["captures", "capture_count"])
+        mock_query.captures = Mock(
+            return_value=[
+                ("name", Mock(text=b"User", start_point=(0, 10), end_point=(0, 14), start_byte=10, end_byte=14)),
+                (
+                    "definition.interface",
+                    Mock(
+                        text=b"interface User { id: number; }",
+                        start_point=(0, 0),
+                        end_point=(0, 30),
+                        start_byte=0,
+                        end_byte=30,
+                    ),
+                ),
+            ]
+        )
 
-        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
-            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+        with patch.object(TreeSitterSymbolExtractor, "get_query", return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, "get_parser") as mock_parser:
                 mock_tree = Mock()
                 mock_tree.root_node = Mock()
                 mock_parser.return_value.parse.return_value = mock_tree
@@ -67,15 +89,18 @@ class TestTreeSitterCompatibility:
         # Mock query where matches() exists but fails
         mock_query = Mock()
         mock_query.matches = Mock(side_effect=AttributeError("'Query' object has no attribute 'matches'"))
-        mock_query.captures = Mock(return_value=[
-            ("name", Mock(text=b"Test", start_point=(0, 6), end_point=(0, 10), start_byte=6, end_byte=10)),
-            ("definition.class", Mock(text=b"class Test {}",
-                                    start_point=(0, 0), end_point=(0, 13),
-                                    start_byte=0, end_byte=13))
-        ])
+        mock_query.captures = Mock(
+            return_value=[
+                ("name", Mock(text=b"Test", start_point=(0, 6), end_point=(0, 10), start_byte=6, end_byte=10)),
+                (
+                    "definition.class",
+                    Mock(text=b"class Test {}", start_point=(0, 0), end_point=(0, 13), start_byte=0, end_byte=13),
+                ),
+            ]
+        )
 
-        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
-            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+        with patch.object(TreeSitterSymbolExtractor, "get_query", return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, "get_parser") as mock_parser:
                 mock_tree = Mock()
                 mock_tree.root_node = Mock()
                 mock_parser.return_value.parse.return_value = mock_tree
@@ -97,8 +122,8 @@ class TestTreeSitterCompatibility:
         mock_query.matches = Mock(side_effect=AttributeError("No matches"))
         mock_query.captures = Mock(side_effect=AttributeError("No captures"))
 
-        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
-            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+        with patch.object(TreeSitterSymbolExtractor, "get_query", return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, "get_parser") as mock_parser:
                 mock_tree = Mock()
                 mock_tree.root_node = Mock()
                 mock_parser.return_value.parse.return_value = mock_tree
@@ -116,8 +141,8 @@ class TestTreeSitterCompatibility:
         # Mock query with no matches or captures methods
         mock_query = Mock(spec=[])  # Empty spec means no methods
 
-        with patch.object(TreeSitterSymbolExtractor, 'get_query', return_value=mock_query):
-            with patch.object(TreeSitterSymbolExtractor, 'get_parser') as mock_parser:
+        with patch.object(TreeSitterSymbolExtractor, "get_query", return_value=mock_query):
+            with patch.object(TreeSitterSymbolExtractor, "get_parser") as mock_parser:
                 mock_tree = Mock()
                 mock_tree.root_node = Mock()
                 mock_parser.return_value.parse.return_value = mock_tree

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "cased-kit"
-version = "1.9.0"
+version = "1.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -185,6 +185,7 @@ dependencies = [
     { name = "redis" },
     { name = "requests" },
     { name = "tiktoken" },
+    { name = "tree-sitter" },
     { name = "tree-sitter-language-pack" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
@@ -239,6 +240,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'ml'", specifier = ">=2.2.0" },
     { name = "tiktoken", specifier = ">=0.4.0" },
+    { name = "tree-sitter", specifier = ">=0.25.1" },
     { name = "tree-sitter-language-pack", specifier = ">=0.7.2" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "typer", specifier = ">=0.9,<0.16" },
@@ -3106,38 +3108,45 @@ wheels = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a2/698b9d31d08ad5558f8bfbfe3a0781bd4b1f284e89bde3ad18e05101a892/tree-sitter-0.24.0.tar.gz", hash = "sha256:abd95af65ca2f4f7eca356343391ed669e764f37748b5352946f00f7fc78e734", size = 168304 }
+sdist = { url = "https://files.pythonhosted.org/packages/89/2b/02a642e67605b9dd59986b00d13a076044dede04025a243f0592ac79d68c/tree-sitter-0.25.1.tar.gz", hash = "sha256:cd761ad0e4d1fc88a4b1b8083bae06d4f973acf6f5f29bbf13ea9609c1dec9c1", size = 177874 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/9a/bd627a02e41671af73222316e1fcf87772c7804dc2fba99405275eb1f3eb/tree_sitter-0.24.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f3f00feff1fc47a8e4863561b8da8f5e023d382dd31ed3e43cd11d4cae445445", size = 140890 },
-    { url = "https://files.pythonhosted.org/packages/5b/9b/b1ccfb187f8be78e2116176a091a2f2abfd043a06d78f80c97c97f315b37/tree_sitter-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f9691be48d98c49ef8f498460278884c666b44129222ed6217477dffad5d4831", size = 134413 },
-    { url = "https://files.pythonhosted.org/packages/01/39/e25b0042a049eb27e991133a7aa7c49bb8e49a8a7b44ca34e7e6353ba7ac/tree_sitter-0.24.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:098a81df9f89cf254d92c1cd0660a838593f85d7505b28249216661d87adde4a", size = 560427 },
-    { url = "https://files.pythonhosted.org/packages/1c/59/4d132f1388da5242151b90acf32cc56af779bfba063923699ab28b276b62/tree_sitter-0.24.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b26bf9e958da6eb7e74a081aab9d9c7d05f9baeaa830dbb67481898fd16f1f5", size = 574327 },
-    { url = "https://files.pythonhosted.org/packages/ec/97/3914e45ab9e0ff0f157e493caa91791372508488b97ff0961a0640a37d25/tree_sitter-0.24.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2a84ff87a2f2a008867a1064aba510ab3bd608e3e0cd6e8fef0379efee266c73", size = 577171 },
-    { url = "https://files.pythonhosted.org/packages/c5/b0/266a529c3eef171137b73cde8ad7aa282734354609a8b2f5564428e8f12d/tree_sitter-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:c012e4c345c57a95d92ab5a890c637aaa51ab3b7ff25ed7069834b1087361c95", size = 120260 },
-    { url = "https://files.pythonhosted.org/packages/c1/c3/07bfaa345e0037ff75d98b7a643cf940146e4092a1fd54eed0359836be03/tree_sitter-0.24.0-cp310-cp310-win_arm64.whl", hash = "sha256:033506c1bc2ba7bd559b23a6bdbeaf1127cee3c68a094b82396718596dfe98bc", size = 108416 },
-    { url = "https://files.pythonhosted.org/packages/66/08/82aaf7cbea7286ee2a0b43e9b75cb93ac6ac132991b7d3c26ebe5e5235a3/tree_sitter-0.24.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de0fb7c18c6068cacff46250c0a0473e8fc74d673e3e86555f131c2c1346fb13", size = 140733 },
-    { url = "https://files.pythonhosted.org/packages/8c/bd/1a84574911c40734d80327495e6e218e8f17ef318dd62bb66b55c1e969f5/tree_sitter-0.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a7c9c89666dea2ce2b2bf98e75f429d2876c569fab966afefdcd71974c6d8538", size = 134243 },
-    { url = "https://files.pythonhosted.org/packages/46/c1/c2037af2c44996d7bde84eb1c9e42308cc84b547dd6da7f8a8bea33007e1/tree_sitter-0.24.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ddb113e6b8b3e3b199695b1492a47d87d06c538e63050823d90ef13cac585fd", size = 562030 },
-    { url = "https://files.pythonhosted.org/packages/4c/aa/2fb4d81886df958e6ec7e370895f7106d46d0bbdcc531768326124dc8972/tree_sitter-0.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01ea01a7003b88b92f7f875da6ba9d5d741e0c84bb1bd92c503c0eecd0ee6409", size = 575585 },
-    { url = "https://files.pythonhosted.org/packages/e3/3c/5f997ce34c0d1b744e0f0c0757113bdfc173a2e3dadda92c751685cfcbd1/tree_sitter-0.24.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:464fa5b2cac63608915a9de8a6efd67a4da1929e603ea86abaeae2cb1fe89921", size = 578203 },
-    { url = "https://files.pythonhosted.org/packages/d5/1f/f2bc7fa7c3081653ea4f2639e06ff0af4616c47105dbcc0746137da7620d/tree_sitter-0.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:3b1f3cbd9700e1fba0be2e7d801527e37c49fc02dc140714669144ef6ab58dce", size = 120147 },
-    { url = "https://files.pythonhosted.org/packages/c0/4c/9add771772c4d72a328e656367ca948e389432548696a3819b69cdd6f41e/tree_sitter-0.24.0-cp311-cp311-win_arm64.whl", hash = "sha256:f3f08a2ca9f600b3758792ba2406971665ffbad810847398d180c48cee174ee2", size = 108302 },
-    { url = "https://files.pythonhosted.org/packages/e9/57/3a590f287b5aa60c07d5545953912be3d252481bf5e178f750db75572bff/tree_sitter-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14beeff5f11e223c37be7d5d119819880601a80d0399abe8c738ae2288804afc", size = 140788 },
-    { url = "https://files.pythonhosted.org/packages/61/0b/fc289e0cba7dbe77c6655a4dd949cd23c663fd62a8b4d8f02f97e28d7fe5/tree_sitter-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26a5b130f70d5925d67b47db314da209063664585a2fd36fa69e0717738efaf4", size = 133945 },
-    { url = "https://files.pythonhosted.org/packages/86/d7/80767238308a137e0b5b5c947aa243e3c1e3e430e6d0d5ae94b9a9ffd1a2/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fc5c3c26d83c9d0ecb4fc4304fba35f034b7761d35286b936c1db1217558b4e", size = 564819 },
-    { url = "https://files.pythonhosted.org/packages/bf/b3/6c5574f4b937b836601f5fb556b24804b0a6341f2eb42f40c0e6464339f4/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:772e1bd8c0931c866b848d0369b32218ac97c24b04790ec4b0e409901945dd8e", size = 579303 },
-    { url = "https://files.pythonhosted.org/packages/0a/f4/bd0ddf9abe242ea67cca18a64810f8af230fc1ea74b28bb702e838ccd874/tree_sitter-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:24a8dd03b0d6b8812425f3b84d2f4763322684e38baf74e5bb766128b5633dc7", size = 581054 },
-    { url = "https://files.pythonhosted.org/packages/8c/1c/ff23fa4931b6ef1bbeac461b904ca7e49eaec7e7e5398584e3eef836ec96/tree_sitter-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9e8b1605ab60ed43803100f067eed71b0b0e6c1fb9860a262727dbfbbb74751", size = 120221 },
-    { url = "https://files.pythonhosted.org/packages/b2/2a/9979c626f303177b7612a802237d0533155bf1e425ff6f73cc40f25453e2/tree_sitter-0.24.0-cp312-cp312-win_arm64.whl", hash = "sha256:f733a83d8355fc95561582b66bbea92ffd365c5d7a665bc9ebd25e049c2b2abb", size = 108234 },
-    { url = "https://files.pythonhosted.org/packages/61/cd/2348339c85803330ce38cee1c6cbbfa78a656b34ff58606ebaf5c9e83bd0/tree_sitter-0.24.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d4a6416ed421c4210f0ca405a4834d5ccfbb8ad6692d4d74f7773ef68f92071", size = 140781 },
-    { url = "https://files.pythonhosted.org/packages/8b/a3/1ea9d8b64e8dcfcc0051028a9c84a630301290995cd6e947bf88267ef7b1/tree_sitter-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0992d483677e71d5c5d37f30dfb2e3afec2f932a9c53eec4fca13869b788c6c", size = 133928 },
-    { url = "https://files.pythonhosted.org/packages/fe/ae/55c1055609c9428a4aedf4b164400ab9adb0b1bf1538b51f4b3748a6c983/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57277a12fbcefb1c8b206186068d456c600dbfbc3fd6c76968ee22614c5cd5ad", size = 564497 },
-    { url = "https://files.pythonhosted.org/packages/ce/d0/f2ffcd04882c5aa28d205a787353130cbf84b2b8a977fd211bdc3b399ae3/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25fa22766d63f73716c6fec1a31ee5cf904aa429484256bd5fdf5259051ed74", size = 578917 },
-    { url = "https://files.pythonhosted.org/packages/af/82/aebe78ea23a2b3a79324993d4915f3093ad1af43d7c2208ee90be9273273/tree_sitter-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d5d9537507e1c8c5fa9935b34f320bfec4114d675e028f3ad94f11cf9db37b9", size = 581148 },
-    { url = "https://files.pythonhosted.org/packages/a1/b4/6b0291a590c2b0417cfdb64ccb8ea242f270a46ed429c641fbc2bfab77e0/tree_sitter-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:f58bb4956917715ec4d5a28681829a8dad5c342cafd4aea269f9132a83ca9b34", size = 120207 },
-    { url = "https://files.pythonhosted.org/packages/a8/18/542fd844b75272630229c9939b03f7db232c71a9d82aadc59c596319ea6a/tree_sitter-0.24.0-cp313-cp313-win_arm64.whl", hash = "sha256:23641bd25dcd4bb0b6fa91b8fb3f46cc9f1c9f475efe4d536d3f1f688d1b84c8", size = 108232 },
+    { url = "https://files.pythonhosted.org/packages/e0/6c/6160ca15926d11a6957d8bee887f477f3c1d9bc5272c863affc0b50b9cff/tree_sitter-0.25.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a15d62ffdb095d509bda8c140c1ddd0cc80f0c67f92b87fcc96cd242dc0c71ea", size = 146692 },
+    { url = "https://files.pythonhosted.org/packages/81/4a/e5eb39fe73a514a13bf94acee97925de296d673dace00557763cbbdc938f/tree_sitter-0.25.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d938f0a1ffad1206a1a569b0501345eeca81cae0a4487bb485e53768b02f24e", size = 141015 },
+    { url = "https://files.pythonhosted.org/packages/63/22/c8e3ba245e5cdb8c951482028a7ee99d141302047b708dc9d670f0fafd85/tree_sitter-0.25.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba8cea296de5dcb384b9a15cf526985ac8339c81da51c7e29a251d82071f5ee9", size = 599462 },
+    { url = "https://files.pythonhosted.org/packages/c2/91/c866c3d278ee86354fd81fd055b5d835c510b0e9af07e1cf7e48e2f946b0/tree_sitter-0.25.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:387fd2bd8657d69e877618dc199c18e2d6fe073b8f5c59e23435f3baee4ee10a", size = 627062 },
+    { url = "https://files.pythonhosted.org/packages/90/96/ac010f72778dae60381ab5fcca9651ac72647d582db0b027ca6c56116920/tree_sitter-0.25.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:afa49e51f82b58ae2c1291d6b79ca31e0fb36c04bd9a20d89007472edfb70136", size = 623788 },
+    { url = "https://files.pythonhosted.org/packages/0e/29/190bdfd54a564a2e43a702884ad5679f4578c481a46161f9f335dd390a70/tree_sitter-0.25.1-cp310-cp310-win_amd64.whl", hash = "sha256:77be45f666adf284914510794b41100decccd71dba88010c03dc2bb0d653acec", size = 127253 },
+    { url = "https://files.pythonhosted.org/packages/da/60/7daca5ccf65fb204c9f2cc2907db6aeaf1cb42aa605427580c17a38a53b3/tree_sitter-0.25.1-cp310-cp310-win_arm64.whl", hash = "sha256:72badac2de4e81ae0df5efe14ec5003bd4df3e48e7cf84dbd9df3a54599ba371", size = 113930 },
+    { url = "https://files.pythonhosted.org/packages/17/dc/0dabb75d249108fb9062d6e9e791e4ad8e9ae5c095e06dd8af770bc07902/tree_sitter-0.25.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:33a8fbaeb2b5049cf5318306ab8b16ab365828b2b21ee13678c29e0726a1d27a", size = 146696 },
+    { url = "https://files.pythonhosted.org/packages/da/d0/b7305a05d65dbcfce7a97a93252bf7384f09800866e9de55a625c76e0257/tree_sitter-0.25.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:797bbbc686d8d3722d25ee0108ad979bda6ad3e1025859ce2ee290e517816bd4", size = 141014 },
+    { url = "https://files.pythonhosted.org/packages/84/d0/d0d8bd13c44ef6379499712a3f5e3930e7db11e5c8eb2af8655e288597a3/tree_sitter-0.25.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629fc2ae3f5954b0f6a7b42ee3fcd8f34b68ea161e9f02fa5bf709cbbac996d3", size = 604339 },
+    { url = "https://files.pythonhosted.org/packages/c5/13/22869a6da25ffe2dfff922712605e72a9c3481109a93f4218bea1bc65f35/tree_sitter-0.25.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4257018c42a33a7935a5150d678aac05c6594347d6a6e6dbdf7e2ef4ae985213", size = 631593 },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/f4590fc08422768fc57456a85c932888a02e7a13540574859308611be1cf/tree_sitter-0.25.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4027854c9feee2a3bb99642145ba04ce95d75bd17e292911c93a488cb28d0a04", size = 629265 },
+    { url = "https://files.pythonhosted.org/packages/a7/a8/ee9305ce9a7417715cbf038fdcc4fdb6042e30065c9837bdcf36be440388/tree_sitter-0.25.1-cp311-cp311-win_amd64.whl", hash = "sha256:183faaedcee5f0a3ba39257fa81749709d5eb7cf92c2c050b36ff38468d1774c", size = 127210 },
+    { url = "https://files.pythonhosted.org/packages/48/64/6a39882f534373873ef3dba8a1a8f47dc3bfb39ee63784eac2e789b404c4/tree_sitter-0.25.1-cp311-cp311-win_arm64.whl", hash = "sha256:6a3800235535a2532ce392ed0d8e6f698ee010e73805bdeac2f249da8246bab6", size = 113928 },
+    { url = "https://files.pythonhosted.org/packages/45/79/6dea0c098879d99f41ba919da1ea46e614fb4bf9c4d591450061aeec6fcb/tree_sitter-0.25.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9362a202144075b54f7c9f07e0b0e44a61eed7ee19e140c506b9e64c1d21ed58", size = 146928 },
+    { url = "https://files.pythonhosted.org/packages/15/30/8002f4e76c7834a6101895ff7524ea29ab4f1f1da1270260ef52e2319372/tree_sitter-0.25.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:593f22529f34dd04de02f56ea6d7c2c8ec99dfab25b58be893247c1090dedd60", size = 140802 },
+    { url = "https://files.pythonhosted.org/packages/38/ec/d297ad9d4a4b26f551a5ca49afe48fdbcb20f058c2eff8d8463ad6c0eed1/tree_sitter-0.25.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ebb6849f76e1cbfa223303fa680da533d452e378d5fe372598e4752838ca7929", size = 606762 },
+    { url = "https://files.pythonhosted.org/packages/4a/1c/05a623cfb420b10d5f782d4ec064cf00fbfa9c21b8526ca4fd042f80acff/tree_sitter-0.25.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:034d4544bb0f82e449033d76dd083b131c3f9ecb5e37d3475f80ae55e8f382bd", size = 634632 },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/f05fd5a2331c16d428efb8eef32dfb80dc6565438146e34e9a235ecd7925/tree_sitter-0.25.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:46a9b721560070f2f980105266e28a17d3149485582cdba14d66dca14692e932", size = 630756 },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/79f3c5d53d1721b95ab6cda0368192a4f1d367e3a5ff7ac21d77e9841782/tree_sitter-0.25.1-cp312-cp312-win_amd64.whl", hash = "sha256:9a5c522b1350a626dc1cbc5dc203133caeaa114d3f65e400445e8b02f18b343b", size = 127157 },
+    { url = "https://files.pythonhosted.org/packages/24/b7/07c4e3f71af0096db6c2ecd83e7d61584e3891c79cb39b208082312d1d60/tree_sitter-0.25.1-cp312-cp312-win_arm64.whl", hash = "sha256:43e7b8e83f9fc29ca62e7d2aa8c38e3fa806ff3fc65e0d501d18588dc1509888", size = 113910 },
+    { url = "https://files.pythonhosted.org/packages/3f/d3/bfb08aab9c7daed2715f303cc017329e3512bb77678cc28829681decadd2/tree_sitter-0.25.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae1eebc175e6a50b38b0e0385cdc26e92ac0bff9b32ee1c0619bbbf6829d57ea", size = 146920 },
+    { url = "https://files.pythonhosted.org/packages/f9/36/7f897c50489c38665255579646fca8191e1b9e5a29ac9cf11022e42e1e2b/tree_sitter-0.25.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e0ae03c4f132f1bffb2bc40b1bb28742785507da693ab04da8531fe534ada9c", size = 140782 },
+    { url = "https://files.pythonhosted.org/packages/16/e6/85012113899296b8e0789ae94f562d3971d7d3df989e8bec6128749394e1/tree_sitter-0.25.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acf571758be0a71046a61a0936cb815f15b13e0ae7ec6d08398e4aa1560b371d", size = 607590 },
+    { url = "https://files.pythonhosted.org/packages/49/93/605b08dc4cf76d08cfacebc30a88467c6526ea5c94592c25240518e38b71/tree_sitter-0.25.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:632910847e3f8ae35841f92cba88a9a1b8bc56ecc1514a5affebf7951fa0fc0a", size = 635553 },
+    { url = "https://files.pythonhosted.org/packages/ce/27/123667f756bb32168507c940db9040104c606fbb0214397d3c20cf985073/tree_sitter-0.25.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a99ecef7771afb118b2a8435c8ba67ea7a085c60d5d33dc0a4794ed882e5f7df", size = 630844 },
+    { url = "https://files.pythonhosted.org/packages/2f/53/180b0ed74153a3c9a23967f54774d5930c2e0b67671ae4ca0d4d35ba18ac/tree_sitter-0.25.1-cp313-cp313-win_amd64.whl", hash = "sha256:c1d6393454d1f9d4195c74e40a487640cd4390cd4aee90837485f932a1a0f40c", size = 127159 },
+    { url = "https://files.pythonhosted.org/packages/32/fb/b8b7b5122ac4a80cd689a5023f2416910e10f9534ace1cdf0020a315d40d/tree_sitter-0.25.1-cp313-cp313-win_arm64.whl", hash = "sha256:c1d2dbf7d12426b71ff49739f599c355f4de338a5c0ab994de2a1d290f6e0b20", size = 113920 },
+    { url = "https://files.pythonhosted.org/packages/70/8c/cb851da552baf4215baf96443e5e9e39095083a95bc05c4444e640fe0fe8/tree_sitter-0.25.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:32cee52264d9ecf98885fcac0185ac63e16251b31dd8b4a3b8d8071173405f8f", size = 146775 },
+    { url = "https://files.pythonhosted.org/packages/f3/59/002c89df1e8f1664b82023e5d0c06de97fff5c2a2e33dce1a241c8909758/tree_sitter-0.25.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ae024d8ccfef51e61c44a81af7a48670601430701c24f450bea10f4b4effd8d1", size = 140787 },
+    { url = "https://files.pythonhosted.org/packages/39/48/c9e6deb88f3c7f16963ef205e5b8e3ea7f5effd048b4515d09738c7b032b/tree_sitter-0.25.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d025c56c393cea660df9ef33ca60329952a1f8ee6212d21b2b390dfec08a3874", size = 609173 },
+    { url = "https://files.pythonhosted.org/packages/53/a8/b782576d7ea081a87285d974005155da03b6d0c66283fe1e3a5e0dd4bd98/tree_sitter-0.25.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:044aa23ea14f337809821bea7467f33f4c6d351739dca76ba0cbe4d0154d8662", size = 635994 },
+    { url = "https://files.pythonhosted.org/packages/70/0a/c5b6c9cdb7bd4bf0c3d2bd494fcf356acc53f8e63007dc2a836d95bbe964/tree_sitter-0.25.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1863d96704eb002df4ad3b738294ae8bd5dcf8cefb715da18bff6cb2d33d978e", size = 630944 },
+    { url = "https://files.pythonhosted.org/packages/12/2a/d0b097157c2d487f5e6293dae2c106ec9ede792a6bb780249e81432e754d/tree_sitter-0.25.1-cp314-cp314-win_amd64.whl", hash = "sha256:a40a481e28e1afdbc455932d61e49ffd4163aafa83f4a3deb717524a7786197e", size = 130831 },
+    { url = "https://files.pythonhosted.org/packages/ce/33/3591e7b22dd49f46ae4fdee1db316ecefd0486cae880c5b497a55f0ccb24/tree_sitter-0.25.1-cp314-cp314-win_arm64.whl", hash = "sha256:f7b68f584336b39b2deab9896b629dddc3c784170733d3409f01fe825e9c04eb", size = 117376 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://github.com/cased/kit/issues/134, as the tree-sitter library continues to change its interface. Add additional compatibility, and tighten our dep range.