### PR TITLE
Add tree-sitter Zig language support

### DIFF
--- a/src/kit/queries/zig/tags.scm
+++ b/src/kit/queries/zig/tags.scm
@@ -1,0 +1,37 @@
+;; tags.scm for Zig symbol extraction
+
+; Function declarations with bodies
+((Decl
+  (FnProto
+    function: (IDENTIFIER) @name)
+  (Block)) @definition.function)
+
+; Struct declarations via const bindings
+(VarDecl
+  (IDENTIFIER) @name
+  (ErrorUnionExpr
+    (SuffixExpr
+      (ContainerDecl
+        (ContainerDeclType) @container_kind
+        (#match? @container_kind "^struct")
+      ) @definition.struct)))
+
+; Enum declarations via const bindings
+(VarDecl
+  (IDENTIFIER) @name
+  (ErrorUnionExpr
+    (SuffixExpr
+      (ContainerDecl
+        (ContainerDeclType) @container_kind
+        (#match? @container_kind "^enum")
+      ) @definition.enum)))
+
+; Union declarations via const bindings
+(VarDecl
+  (IDENTIFIER) @name
+  (ErrorUnionExpr
+    (SuffixExpr
+      (ContainerDecl
+        (ContainerDeclType) @container_kind
+        (#match? @container_kind "^union")
+      ) @definition.union)))

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -32,6 +32,7 @@ LANGUAGES: dict[str, str] = {
     ".cxx": "cpp",
     ".hpp": "cpp",
     ".hxx": "cpp",
+    ".zig": "zig",
 }
 
 
@@ -346,6 +347,7 @@ class TreeSitterSymbolExtractor:
             ".cxx": "cpp",
             ".hpp": "cpp",
             ".hxx": "cpp",
+            ".zig": "zig",
         }
         LANGUAGES.clear()
         LANGUAGES.update(original_languages)

--- a/tests/test_symbol_extraction_multilang.py
+++ b/tests/test_symbol_extraction_multilang.py
@@ -8,6 +8,7 @@ SAMPLES = {
     ".go": "package main\n\nfunc foo() {}\n\ntype Bar struct{}\n",
     ".java": "class Bar { void foo() {} }\n",
     ".rs": "fn foo() {}\nstruct Bar;\n",
+    ".zig": "pub fn foo() void {}\npub const Bar = struct {};\n",
 }
 
 

--- a/tests/test_tree_sitter_languages.py
+++ b/tests/test_tree_sitter_languages.py
@@ -11,6 +11,7 @@ LANG_SAMPLES = {
     "hcl": b'variable "foo" { default = 42 }\n',
     "c": b"int foo() { return 42; }\n",
     "dart": b"int foo() { return 42; }\n",
+    "zig": b"pub fn foo() void { }\n",
 }
 
 


### PR DESCRIPTION
## Summary
- add zig language mapping and tree-sitter queries
- cover zig in symbol extraction tests

## Testing
- uv run pytest tests/test_tree_sitter_symbol_extractor.py tests/test_tree_sitter_languages.py tests/test_symbol_extraction_multilang.py