### PR TITLE
Fix Windows cp950 encoding error with non-ASCII paths

### DIFF
--- a/benchmarks/benchmark_ripgrep.py
+++ b/benchmarks/benchmark_ripgrep.py
@@ -2,6 +2,7 @@
 """Benchmark ripgrep and Python implementations for code search."""
 
 import time
+
 from kit.code_searcher import CodeSearcher, SearchOptions
 
 
@@ -103,7 +104,7 @@ def main():
                 rg_times.append(elapsed)
             rg_avg = sum(rg_times) / len(rg_times)
             rg_min = min(rg_times)
-            print(f"  Ripgrep:  avg={rg_avg*1000:.1f}ms  min={rg_min*1000:.1f}ms  ({count} matches)")
+            print(f"  Ripgrep:  avg={rg_avg * 1000:.1f}ms  min={rg_min * 1000:.1f}ms  ({count} matches)")
             bench_result["rg_avg"] = rg_avg
             bench_result["matches"] = count
 
@@ -116,7 +117,7 @@ def main():
             py_times.append(elapsed)
         py_avg = sum(py_times) / len(py_times)
         py_min = min(py_times)
-        print(f"  Python:   avg={py_avg*1000:.1f}ms  min={py_min*1000:.1f}ms  ({count} matches)")
+        print(f"  Python:   avg={py_avg * 1000:.1f}ms  min={py_min * 1000:.1f}ms  ({count} matches)")
         bench_result["py_avg"] = py_avg
         if "matches" not in bench_result:
             bench_result["matches"] = count
@@ -145,13 +146,13 @@ def main():
 
         print(f"\nTotal time for all {len(results)} searches:")
         total_py = sum(r["py_avg"] for r in results)
-        print(f"  Python:  {total_py*1000:.1f}ms")
+        print(f"  Python:  {total_py * 1000:.1f}ms")
 
         if has_rg:
             total_rg = sum(r.get("rg_avg", 0) for r in results)
             saved_ms = (total_py - total_rg) * 1000
             saved_pct = (1 - total_rg / total_py) * 100
-            print(f"  Ripgrep: {total_rg*1000:.1f}ms (saved {saved_ms:.1f}ms, {saved_pct:.0f}%)")
+            print(f"  Ripgrep: {total_rg * 1000:.1f}ms (saved {saved_ms:.1f}ms, {saved_pct:.0f}%)")
 
 
 if __name__ == "__main__":

--- a/src/kit/api/app.py
+++ b/src/kit/api/app.py
@@ -119,21 +119,14 @@ def validate_repo_url(url: str) -> None:
         hostname = parsed.hostname
 
         if not hostname:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid repository URL: hostname not found"
-            )
+            raise HTTPException(status_code=400, detail="Invalid repository URL: hostname not found")
 
         # Check if URL matches any allowed pattern
         for pattern in ALLOWED_REPO_PATTERNS:
             if matches_pattern(url, pattern):
                 logger.info(
                     f"Repository URL validated: {sanitize_url(url)}",
-                    extra={
-                        "event_type": "url_validated",
-                        "hostname": hostname,
-                        "matched_pattern": pattern
-                    }
+                    extra={"event_type": "url_validated", "hostname": hostname, "matched_pattern": pattern},
                 )
                 return  # URL is allowed
 
@@ -143,29 +136,20 @@ def validate_repo_url(url: str) -> None:
             extra={
                 "event_type": "url_rejected_by_allowlist",
                 "hostname": hostname,
-                "allowed_patterns": ALLOWED_REPO_PATTERNS
-            }
+                "allowed_patterns": ALLOWED_REPO_PATTERNS,
+            },
         )
         raise HTTPException(
             status_code=403,
             detail=f"Repository URL does not match any allowed pattern. "
-                   f"Allowed patterns: {', '.join(ALLOWED_REPO_PATTERNS)}"
+            f"Allowed patterns: {', '.join(ALLOWED_REPO_PATTERNS)}",
         )
     except HTTPException:
         # Re-raise HTTPExceptions as-is
         raise
     except Exception as e:
-        logger.error(
-            f"Error parsing repository URL: {str(e)}",
-            extra={
-                "event_type": "url_parse_error",
-                "error": str(e)
-            }
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid repository URL format: {str(e)}"
-        )
+        logger.error(f"Error parsing repository URL: {e!s}", extra={"event_type": "url_parse_error", "error": str(e)})
+        raise HTTPException(status_code=400, detail=f"Invalid repository URL format: {e!s}")
 
 
 class RepoIn(BaseModel):

--- a/src/kit/api/registry.py
+++ b/src/kit/api/registry.py
@@ -44,7 +44,9 @@ def _canonical(value: str, ref: str | None = None) -> str:
     try:
         import subprocess
 
-        result = subprocess.run(["git", "-C", base, "rev-parse", "HEAD"], capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            ["git", "-C", base, "rev-parse", "HEAD"], capture_output=True, text=True, encoding="utf-8", check=False
+        )
         if result.returncode == 0:
             ref = result.stdout.strip()
     except Exception:

--- a/src/kit/cli.py
+++ b/src/kit/cli.py
@@ -13,6 +13,7 @@ def _get_version() -> str:
     """Get kit version without importing the entire package."""
     try:
         from importlib.metadata import version
+
         return version("cased-kit")
     except Exception:
         return "unknown"

--- a/src/kit/code_searcher.py
+++ b/src/kit/code_searcher.py
@@ -67,12 +67,7 @@ class CodeSearcher:
     def _has_ripgrep(self) -> bool:
         """Check if ripgrep (rg) is available on the system."""
         try:
-            subprocess.run(
-                ["rg", "--version"],
-                capture_output=True,
-                check=True,
-                timeout=1
-            )
+            subprocess.run(["rg", "--version"], capture_output=True, check=True, timeout=1)
             return True
         except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
             return False
@@ -96,8 +91,12 @@ class CodeSearcher:
         return messages
 
     def _extract_context_for_match(
-        self, messages: List[Dict[str, Any]], match_index: int,
-        file_path: str, match_line_number: int, options: SearchOptions
+        self,
+        messages: List[Dict[str, Any]],
+        match_index: int,
+        file_path: str,
+        match_line_number: int,
+        options: SearchOptions,
     ) -> tuple[List[str], List[str]]:
         """Extract context lines before and after a match from ripgrep messages."""
         context_before: List[str] = []
@@ -167,7 +166,7 @@ class CodeSearcher:
         cmd.extend([query, str(self.repo_path)])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=30)
             messages = self._parse_ripgrep_json_messages(result.stdout)
 
             matches = []
@@ -188,13 +187,15 @@ class CodeSearcher:
                         messages, i, file_path, match_line_number, options
                     )
 
-                    matches.append({
-                        "file": rel_path,
-                        "line_number": match_line_number,
-                        "line": line_text,
-                        "context_before": context_before,
-                        "context_after": context_after
-                    })
+                    matches.append(
+                        {
+                            "file": rel_path,
+                            "line_number": match_line_number,
+                            "line": line_text,
+                            "context_before": context_before,
+                            "context_after": context_after,
+                        }
+                    )
 
             return matches
         except (subprocess.TimeoutExpired, Exception):

--- a/src/kit/pr_review/commit_generator.py
+++ b/src/kit/pr_review/commit_generator.py
@@ -21,7 +21,9 @@ class CommitMessageGenerator:
     def get_staged_diff(self) -> str:
         """Get the diff of staged changes."""
         try:
-            result = subprocess.run(["git", "diff", "--cached"], capture_output=True, text=True, check=True)
+            result = subprocess.run(
+                ["git", "diff", "--cached"], capture_output=True, text=True, encoding="utf-8", check=True
+            )
             return result.stdout
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to get staged diff: {e}")
@@ -30,7 +32,7 @@ class CommitMessageGenerator:
         """Get list of staged files."""
         try:
             result = subprocess.run(
-                ["git", "diff", "--cached", "--name-only"], capture_output=True, text=True, check=True
+                ["git", "diff", "--cached", "--name-only"], capture_output=True, text=True, encoding="utf-8", check=True
             )
             return [f.strip() for f in result.stdout.splitlines() if f.strip()]
         except subprocess.CalledProcessError as e:
@@ -282,7 +284,9 @@ Generate only the commit message, nothing else."""
     def commit_with_message(self, message: str) -> None:
         """Execute git commit with the generated message."""
         try:
-            subprocess.run(["git", "commit", "-m", message], check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "commit", "-m", message], check=True, capture_output=True, text=True, encoding="utf-8"
+            )
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to commit: {e.stderr}")
 

--- a/src/kit/pr_review/local_reviewer.py
+++ b/src/kit/pr_review/local_reviewer.py
@@ -292,6 +292,7 @@ class LocalDiffReviewer:
                 cwd=self.repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=30,  # Prevent hanging on large operations
                 shell=False,  # Never use shell=True
             )

--- a/src/kit/repository.py
+++ b/src/kit/repository.py
@@ -101,7 +101,12 @@ class Repository:
 
             # Checkout the ref
             _ = subprocess.run(
-                ["git", "checkout", ref], cwd=str(self.local_path), capture_output=True, text=True, check=True
+                ["git", "checkout", ref],
+                cwd=str(self.local_path),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
             )
         except subprocess.CalledProcessError as e:
             raise ValueError(f"Failed to checkout ref '{ref}': {e.stderr}")
@@ -152,7 +157,9 @@ class Repository:
             return None
 
         try:
-            result = subprocess.run(cmd, cwd=self.repo_path, capture_output=True, text=True, check=True)
+            result = subprocess.run(
+                cmd, cwd=self.repo_path, capture_output=True, text=True, encoding="utf-8", check=True
+            )
             return result.stdout.strip() if result.stdout else None
         except subprocess.CalledProcessError:
             return None
@@ -173,7 +180,7 @@ class Repository:
                 branch_cmd = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
                 # Use self.repo_path (string) for cwd as subprocess expects string path
                 branch_result = subprocess.run(
-                    branch_cmd, cwd=self.repo_path, capture_output=True, text=True, check=False
+                    branch_cmd, cwd=self.repo_path, capture_output=True, text=True, encoding="utf-8", check=False
                 )
                 if branch_result.returncode == 0 and branch_result.stdout.strip() != "HEAD":
                     ref_info = f", branch: {branch_result.stdout.strip()}"
@@ -181,7 +188,7 @@ class Repository:
                     # If not on a branch (detached HEAD), get commit SHA
                     sha_cmd = ["git", "rev-parse", "--short", "HEAD"]
                     sha_result = subprocess.run(
-                        sha_cmd, cwd=self.repo_path, capture_output=True, text=True, check=False
+                        sha_cmd, cwd=self.repo_path, capture_output=True, text=True, encoding="utf-8", check=False
                     )
                     if sha_result.returncode == 0:
                         ref_info = f", commit: {sha_result.stdout.strip()}"
@@ -216,12 +223,22 @@ class Repository:
             if ref:
                 try:
                     current_sha = subprocess.run(
-                        ["git", "rev-parse", "HEAD"], cwd=str(repo_path), capture_output=True, text=True, check=True
+                        ["git", "rev-parse", "HEAD"],
+                        cwd=str(repo_path),
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        check=True,
                     ).stdout.strip()
 
                     # Check if we're already on the requested ref
                     target_sha = subprocess.run(
-                        ["git", "rev-parse", ref], cwd=str(repo_path), capture_output=True, text=True, check=False
+                        ["git", "rev-parse", ref],
+                        cwd=str(repo_path),
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        check=False,
                     )
 
                     if target_sha.returncode != 0 or current_sha != target_sha.stdout.strip():
@@ -467,6 +484,7 @@ class Repository:
                 cwd=str(self.local_path),
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=30,  # 30 second timeout
             )
         except subprocess.TimeoutExpired:

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -1,7 +1,6 @@
 """Tests for REST API security features including URL sanitization and error handling."""
 
 import logging
-import os
 import subprocess
 import time
 from unittest.mock import MagicMock, patch
@@ -453,7 +452,6 @@ class TestURLAllowlist:
 
     def test_allowlist_disabled_by_default(self):
         """Test that when no allowlist is configured, all URLs are allowed."""
-        from fastapi import HTTPException
 
         # When ALLOWED_REPO_PATTERNS is empty, validation should pass
         with patch("kit.api.app.ALLOWED_REPO_PATTERNS", []):
@@ -593,8 +591,9 @@ class TestURLAllowlist:
 
     def test_allowlist_integration_with_open_repo(self):
         """Test that allowlist is enforced in the open_repo endpoint."""
-        from kit.api.app import RepoIn, open_repo
         from fastapi import HTTPException
+
+        from kit.api.app import RepoIn, open_repo
 
         with patch("kit.api.app.ALLOWED_REPO_PATTERNS", ["github.com"]):
             # Allowed domain should work (assuming repo operations succeed)

--- a/tests/test_grep_integration.py
+++ b/tests/test_grep_integration.py
@@ -206,3 +206,97 @@ class TestGrepIntegration:
         python_files = {result["file"] for result in python_results}
         mcp_files = {result["file"] for result in mcp_results}
         assert python_files == mcp_files
+
+    def test_grep_utf8_chinese_content(self):
+        """Test grep with Chinese characters (UTF-8 encoding) - addresses issue #151."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+
+            # Create files with Chinese content
+            (repo_path / "chinese_file.py").write_text(
+                "# 这是中文注释\ndef 测试函数():\n    return '你好世界'\n", encoding="utf-8"
+            )
+            (repo_path / "mixed_content.py").write_text(
+                "def hello():\n    # TODO: 添加中文支持\n    pass\n", encoding="utf-8"
+            )
+
+            repo = Repository(str(repo_path))
+
+            # Test searching for Chinese characters
+            results = repo.grep("测试函数")
+            assert len(results) >= 1
+            assert any("测试函数" in result["line_content"] for result in results)
+
+            # Test searching for Chinese strings
+            results = repo.grep("你好世界")
+            assert len(results) >= 1
+            assert any("你好世界" in result["line_content"] for result in results)
+
+            # Test searching for Chinese comments
+            results = repo.grep("中文注释")
+            assert len(results) >= 1
+            assert any("中文注释" in result["line_content"] for result in results)
+
+    def test_grep_utf8_filename_with_chinese(self):
+        """Test grep with Chinese characters in filename - addresses Windows cp950 issue."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+
+            # Create a file with Chinese filename
+            chinese_filename = "测试文件.py"
+            (repo_path / chinese_filename).write_text("def test():\n    return 'hello'\n", encoding="utf-8")
+
+            repo = Repository(str(repo_path))
+
+            # Search should work and return the filename correctly
+            results = repo.grep("test")
+            assert len(results) >= 1
+
+            # Filename should be preserved correctly (not garbled)
+            found_files = [result["file"] for result in results]
+            assert any(chinese_filename in f or "测试文件" in f for f in found_files)
+
+    def test_grep_utf8_mixed_languages(self):
+        """Test grep with various Unicode characters from different languages."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+
+            # Create files with various Unicode content
+            test_cases = [
+                ("japanese.py", "世界", "# こんにちは世界\ndef hello(): pass\n"),
+                ("korean.py", "안녕하세요", "# 안녕하세요\nclass Test: pass\n"),
+                ("emoji.py", "🚀", "# TODO: 🚀 Launch\ndef launch(): pass\n"),
+                ("french.py", "café", "def café(): # été\n    pass\n"),
+            ]
+
+            for filename, search_term, content in test_cases:
+                (repo_path / filename).write_text(content, encoding="utf-8")
+
+            repo = Repository(str(repo_path))
+
+            # Test each language
+            for filename, search_term, content in test_cases:
+                results = repo.grep(search_term)
+                assert len(results) >= 1, f"Failed to find {search_term} in {filename}"
+                assert any(search_term in result["line_content"] for result in results)
+
+    def test_mcp_grep_utf8_encoding(self):
+        """Test MCP server grep with UTF-8 content - ensures encoding parameter is used."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+
+            # Create file with Chinese content
+            (repo_path / "test.py").write_text("# 中文测试\ndef 函数():\n    return '结果'\n", encoding="utf-8")
+
+            logic = KitServerLogic()
+            repo_id = logic.open_repository(str(repo_path))
+
+            # MCP grep should handle UTF-8 correctly
+            results = logic.grep_code(repo_id, "中文测试")
+            assert len(results) >= 1
+            assert any("中文测试" in result["line_content"] for result in results)
+
+            # Test with function name
+            results = logic.grep_code(repo_id, "函数")
+            assert len(results) >= 1
+            assert any("函数" in result["line_content"] for result in results)


### PR DESCRIPTION
Fixes #151

Added explicit `encoding='utf-8'` to all subprocess calls to fix decoding errors on Windows systems with non-ASCII file paths.

## Changes
- Fixed encoding in ripgrep, grep, and git subprocess calls
- Added comprehensive UTF-8 tests for Chinese, Japanese, Korean, and other Unicode characters
- All tests passing (49/49)