### PR TITLE
Fix arrow function detection in JavaScript/TypeScript symbol extraction

### DIFF
--- a/src/kit/queries/javascript/tags.scm
+++ b/src/kit/queries/javascript/tags.scm
@@ -1,8 +1,79 @@
-; Example tags.scm for JavaScript (tree-sitter-javascript)
+; tags.scm for JavaScript symbol extraction
 ; See https://github.com/tree-sitter/tree-sitter-javascript/blob/master/queries/highlights.scm for reference
 
+; Function declarations
 (function_declaration
-  name: (identifier) @function)
+  name: (identifier) @name @definition.function)
 
+; Class declarations
 (class_declaration
-  name: (identifier) @class)
+  name: (identifier) @name @definition.class)
+
+; Arrow functions assigned to const/let (lexical_declaration)
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (arrow_function)) @definition.function)
+
+; Arrow functions assigned to var (variable_declaration)
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (arrow_function)) @definition.function)
+
+; Regular functions assigned to const/let
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (function_expression)) @definition.function)
+
+; Regular functions assigned to var
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (function_expression)) @definition.function)
+
+; Exported arrow functions (export const/let)
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (arrow_function)) @definition.function))
+
+; Exported arrow functions (export var)
+(export_statement
+  declaration: (variable_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (arrow_function)) @definition.function))
+
+; Exported function expressions
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (function_expression)) @definition.function))
+
+; Exported function declarations
+(export_statement
+  declaration: (function_declaration
+    name: (identifier) @name @definition.function))
+
+; Exported class declarations
+(export_statement
+  declaration: (class_declaration
+    name: (identifier) @name @definition.class))
+
+; Class methods
+(class_body
+  (method_definition
+    name: (property_identifier) @name @definition.method))
+
+; Generator functions
+(generator_function_declaration
+  name: (identifier) @name @definition.function)
+
+; Exported generator functions
+(export_statement
+  declaration: (generator_function_declaration
+    name: (identifier) @name @definition.function))

--- a/src/kit/queries/typescript/tags.scm
+++ b/src/kit/queries/typescript/tags.scm
@@ -1,78 +1,116 @@
 ;; tags.scm for TypeScript symbol extraction
 
-; functions
+; Function declarations
 (function_declaration
   name: (identifier) @name @definition.function)
 
-; classes (with optional modifiers like export)
+; Class declarations (with optional modifiers like export)
 (class_declaration
   name: (type_identifier) @name @definition.class)
 
-; interfaces
+; Interface declarations
 (interface_declaration
   name: (type_identifier) @name @definition.interface)
 
-; enums
+; Enum declarations
 (enum_declaration
   name: (identifier) @name @definition.enum)
 
-; Class methods (implementations, explicitly within class_body)
+; Class methods
 (class_body
   (method_definition
     name: (property_identifier) @name @definition.method))
 
-; Static Class methods (implementations, explicitly within class_body)
-(class_body
-  (method_definition
-    "static"
-    name: (property_identifier) @name @definition.method))
+; Arrow functions assigned to const/let (lexical_declaration)
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (arrow_function)) @definition.function)
 
-; Exported function (variable declarator with function)
+; Arrow functions assigned to var (variable_declaration)
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (arrow_function)) @definition.function)
+
+; Regular functions assigned to const/let
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (function_expression)) @definition.function)
+
+; Regular functions assigned to var
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (function_expression)) @definition.function)
+
+; Exported arrow functions (export const/let)
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (arrow_function)) @definition.function))
+
+; Exported arrow functions (export var)
 (export_statement
   declaration: (variable_declaration
     (variable_declarator
       name: (identifier) @name
-      value: (function_expression)
-    ) @definition.function
-  ))
+      value: (arrow_function)) @definition.function))
 
-; Exported function (variable declarator with arrow function)
+; Exported function expressions (const/let)
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (function_expression)) @definition.function))
+
+; Exported function expressions (var)
 (export_statement
   declaration: (variable_declaration
     (variable_declarator
       name: (identifier) @name
-      value: (arrow_function)
-    ) @definition.function
-  ))
+      value: (function_expression)) @definition.function))
 
-; Exported class
+; Exported function declarations
+(export_statement
+  declaration: (function_declaration
+    name: (identifier) @name @definition.function))
+
+; Exported class declarations
 (export_statement
   declaration: (class_declaration
-    name: (type_identifier) @name @definition.class
-  ))
+    name: (type_identifier) @name @definition.class))
 
-; Exported interface
+; Exported interface declarations
 (export_statement
   declaration: (interface_declaration
-    name: (type_identifier) @name @definition.interface
-  ))
+    name: (type_identifier) @name @definition.interface))
 
-; Exported enum
+; Exported enum declarations
 (export_statement
   declaration: (enum_declaration
-    name: (identifier) @name @definition.enum
-  ))
+    name: (identifier) @name @definition.enum))
 
-; Type alias
+; Type alias declarations
 (type_alias_declaration
-    name: (type_identifier) @name @definition.type)
+  name: (type_identifier) @name @definition.type)
 
-; Exported type alias
+; Exported type alias declarations
 (export_statement
-    declaration: (type_alias_declaration
-        name: (type_identifier) @name @definition.type
-    ))
+  declaration: (type_alias_declaration
+    name: (type_identifier) @name @definition.type))
 
-; Namespace (try internal_module)
+; Namespace (internal_module)
 (internal_module
   name: (identifier) @name @definition.namespace)
+
+; Generator functions
+(generator_function_declaration
+  name: (identifier) @name @definition.function)
+
+; Exported generator functions
+(export_statement
+  declaration: (generator_function_declaration
+    name: (identifier) @name @definition.function))

--- a/tests/test_arrow_function_symbols.py
+++ b/tests/test_arrow_function_symbols.py
@@ -1,0 +1,158 @@
+"""Tests for JavaScript/TypeScript arrow function symbol extraction.
+
+Verifies that arrow functions are properly detected by the symbol extractor.
+See: https://github.com/cased/kit/issues/168
+"""
+import pytest
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+
+class TestJavaScriptArrowFunctions:
+    """Tests for JavaScript arrow function detection."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        """Clear query cache before each test."""
+        TreeSitterSymbolExtractor._queries.clear()
+        yield
+
+    def test_const_arrow_function(self):
+        """Arrow function assigned to const should be detected."""
+        code = "const myFunc = () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_let_arrow_function(self):
+        """Arrow function assigned to let should be detected."""
+        code = "let myFunc = () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_var_arrow_function(self):
+        """Arrow function assigned to var should be detected."""
+        code = "var myFunc = () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_async_arrow_function(self):
+        """Async arrow function should be detected."""
+        code = "const asyncFunc = async () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "asyncFunc" in names
+
+    def test_arrow_function_with_params(self):
+        """Arrow function with parameters should be detected."""
+        code = "const add = (a, b) => a + b;"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "add" in names
+
+    def test_exported_arrow_function(self):
+        """Exported arrow function should be detected."""
+        code = "export const myFunc = () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_function_expression(self):
+        """Function expression should be detected."""
+        code = "const myFunc = function() {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_traditional_function_still_works(self):
+        """Traditional function declaration should still work."""
+        code = "function myFunc() {}"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_class_method_still_works(self):
+        """Class methods should still be detected."""
+        code = """
+class MyClass {
+  myMethod() {}
+}
+"""
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".js", code)
+        names = {s["name"] for s in symbols}
+        assert "MyClass" in names
+        assert "myMethod" in names
+
+
+class TestTypeScriptArrowFunctions:
+    """Tests for TypeScript arrow function detection."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        """Clear query cache before each test."""
+        TreeSitterSymbolExtractor._queries.clear()
+        yield
+
+    def test_const_arrow_function(self):
+        """Arrow function assigned to const should be detected."""
+        code = "const myFunc = () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_typed_arrow_function(self):
+        """Arrow function with type annotations should be detected."""
+        code = "const add = (a: number, b: number): number => a + b;"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+        names = {s["name"] for s in symbols}
+        assert "add" in names
+
+    def test_exported_arrow_function(self):
+        """Exported arrow function should be detected."""
+        code = "export const myFunc = () => {};"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+        names = {s["name"] for s in symbols}
+        assert "myFunc" in names
+
+    def test_interface_still_works(self):
+        """Interface declarations should still work."""
+        code = "interface MyInterface { prop: string; }"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+        names = {s["name"] for s in symbols}
+        assert "MyInterface" in names
+
+    def test_type_alias_still_works(self):
+        """Type alias declarations should still work."""
+        code = "type MyType = string | number;"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".ts", code)
+        names = {s["name"] for s in symbols}
+        assert "MyType" in names
+
+
+class TestTSXArrowFunctions:
+    """Tests for TSX arrow function detection (React components)."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        """Clear query cache before each test."""
+        TreeSitterSymbolExtractor._queries.clear()
+        yield
+
+    def test_arrow_component(self):
+        """Arrow function React component should be detected."""
+        code = "const MyComponent = () => { return <div>Hello</div>; };"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".tsx", code)
+        names = {s["name"] for s in symbols}
+        assert "MyComponent" in names
+
+    def test_exported_arrow_component(self):
+        """Exported arrow function React component should be detected."""
+        code = "export const MyComponent = () => <span>Hi</span>;"
+        symbols = TreeSitterSymbolExtractor.extract_symbols(".tsx", code)
+        names = {s["name"] for s in symbols}
+        assert "MyComponent" in names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_golden_symbols.py
+++ b/tests/test_golden_symbols.py
@@ -98,7 +98,6 @@ def test_typescript_complex_symbol_extraction():
         names_types = {(s["name"], s["type"]) for s in symbols}
 
         # Expected symbols based on current TypeScript query
-        # NOTE: Current query might not capture all nuances (e.g. arrow funcs, namespaces well)
         expected = {
             ("UserProfile", "interface"),
             ("Status", "enum"),
@@ -111,7 +110,7 @@ def test_typescript_complex_symbol_extraction():
             ("add", "method"),  # Method in generic class
             ("getAll", "method"),  # Method in generic class
             ("constructor", "method"),  # Constructor is captured by method query
-            # ("addNumbers", "function"),    # NOT CAPTURED - Arrow function assigned to const
+            ("addNumbers", "function"),  # Arrow function assigned to const (issue #168)
             ("DecoratedClass", "class"),
             ("greet", "method"),
             ("calculateArea", "function"),  # Exported function


### PR DESCRIPTION
## Summary
- Fix `extract_symbols` MCP tool to detect JavaScript/TypeScript arrow functions
- The tree-sitter query files were missing patterns for `lexical_declaration` (used by `const`/`let`)

## Changes
- Update `javascript/tags.scm` to detect arrow functions, function expressions, exports
- Update `typescript/tags.scm` to detect non-exported arrow functions  
- Add 16 new tests for arrow function detection
- Update golden test expectations

Fixes #168