### PR TITLE
Add TOML tree-sitter language support

### DIFF
--- a/docs/src/content/docs/core-concepts/plugin-system.mdx
+++ b/docs/src/content/docs/core-concepts/plugin-system.mdx
@@ -24,6 +24,7 @@ kit comes with built-in support for 12+ programming languages:
 - **Dart** (`.dart`) - Classes, functions, mixins, enums, extensions
 - **HCL/Terraform** (`.hcl`, `.tf`) - Resources, variables, modules
 - **Haskell** (`.hs`) - Module header, functions (including lambda-binds), common type-level declarations
+- **TOML** (`.toml`) - Tables, array tables
 
 Each language supports comprehensive symbol extraction including:
 - **Classes and interfaces** with inheritance relationships

--- a/src/kit/queries/toml/tags.scm
+++ b/src/kit/queries/toml/tags.scm
@@ -1,0 +1,19 @@
+;; tags.scm for TOML symbol extraction (tree-sitter-toml)
+
+; Table headers with bare key: [section]
+(table (bare_key) @name) @definition.table
+
+; Table headers with dotted key: [section.subsection]
+(table (dotted_key) @name) @definition.table
+
+; Table headers with quoted key: ["section.name"]
+(table (quoted_key) @name) @definition.table
+
+; Array table headers with bare key: [[array]]
+(table_array_element (bare_key) @name) @definition.table_array
+
+; Array table headers with dotted key: [[parent.array]]
+(table_array_element (dotted_key) @name) @definition.table_array
+
+; Array table headers with quoted key: [["array.name"]]
+(table_array_element (quoted_key) @name) @definition.table_array

--- a/src/kit/tree_sitter_symbol_extractor.py
+++ b/src/kit/tree_sitter_symbol_extractor.py
@@ -34,6 +34,7 @@ LANGUAGES: dict[str, str] = {
     ".hxx": "cpp",
     ".zig": "zig",
     ".cs": "csharp",
+    ".toml": "toml",
 }
 
 
@@ -350,10 +351,17 @@ class TreeSitterSymbolExtractor:
             ".hxx": "cpp",
             ".zig": "zig",
             ".cs": "csharp",
+            ".toml": "toml",
         }
         LANGUAGES.clear()
         LANGUAGES.update(original_languages)
         cls.LANGUAGES = set(LANGUAGES.keys())
+
+    @staticmethod
+    def _strip_wrapping_quotes(text: str) -> str:
+        if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+            return text[1:-1]
+        return text
 
     @staticmethod
     def extract_symbols(ext: str, source_code: str) -> List[Dict[str, Any]]:
@@ -454,10 +462,12 @@ class TreeSitterSymbolExtractor:
                     if hasattr(actual_name_node, "text") and actual_name_node.text
                     else str(actual_name_node)
                 )
-                # HCL: Strip quotes from string literals
-                if ext == ".tf" and hasattr(actual_name_node, "type") and actual_name_node.type == "string_lit":
-                    if len(symbol_name) >= 2 and symbol_name.startswith('"') and symbol_name.endswith('"'):
-                        symbol_name = symbol_name[1:-1]
+                node_type = actual_name_node.type if hasattr(actual_name_node, "type") else None
+                if (
+                    (ext == ".tf" and node_type == "string_lit")
+                    or (ext == ".toml" and node_type == "quoted_key")
+                ):
+                    symbol_name = TreeSitterSymbolExtractor._strip_wrapping_quotes(symbol_name)
 
                 definition_capture = next(
                     ((name, node) for name, node in captures.items() if name.startswith("definition.")), None

--- a/tests/test_symbol_extraction_multilang.py
+++ b/tests/test_symbol_extraction_multilang.py
@@ -9,6 +9,7 @@ SAMPLES = {
     ".java": "class Bar { void foo() {} }\n",
     ".rs": "fn foo() {}\nstruct Bar;\n",
     ".zig": "pub fn foo() void {}\npub const Bar = struct {};\n",
+    ".toml": "[foo]\nbar = 1\n",
 }
 
 

--- a/tests/test_toml_symbols.py
+++ b/tests/test_toml_symbols.py
@@ -1,0 +1,83 @@
+import pytest
+
+from kit.tree_sitter_symbol_extractor import TreeSitterSymbolExtractor
+
+TOML_SAMPLE = """\
+[package]
+name = "my-app"
+version = "1.0.0"
+
+[dependencies]
+serde = "1.0"
+
+[build.settings]
+opt-level = 2
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[[test]]
+name = "integration"
+"""
+
+TOML_QUOTED_SAMPLE = """\
+["foo.bar"]
+value = 1
+
+[["bin.name"]]
+name = "main"
+
+['lit']
+value = 2
+"""
+
+
+def test_toml_parser_and_query_available():
+    parser = TreeSitterSymbolExtractor.get_parser(".toml")
+    query = TreeSitterSymbolExtractor.get_query(".toml")
+    if not parser or not query:
+        pytest.skip("TOML parser or query not available in this environment")
+
+    tree = parser.parse(TOML_SAMPLE.encode("utf-8"))
+    assert tree.root_node is not None
+
+
+def test_toml_symbols():
+    parser = TreeSitterSymbolExtractor.get_parser(".toml")
+    query = TreeSitterSymbolExtractor.get_query(".toml")
+    if not parser or not query:
+        pytest.skip("TOML parser or query not available in this environment")
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".toml", TOML_SAMPLE)
+    names = {s["name"] for s in symbols}
+    types = {s["type"] for s in symbols}
+
+    assert "package" in names
+    assert "dependencies" in names
+    assert "build.settings" in names
+    assert "bin" in names
+    assert "test" in names
+
+    assert "table" in types
+    assert "table_array" in types
+
+
+def test_toml_quoted_table_names_are_normalized():
+    parser = TreeSitterSymbolExtractor.get_parser(".toml")
+    query = TreeSitterSymbolExtractor.get_query(".toml")
+    if not parser or not query:
+        pytest.skip("TOML parser or query not available in this environment")
+
+    symbols = TreeSitterSymbolExtractor.extract_symbols(".toml", TOML_QUOTED_SAMPLE)
+    names = {s["name"] for s in symbols}
+
+    assert "foo.bar" in names
+    assert "bin.name" in names
+    assert "lit" in names
+
+
+def test_toml_in_supported_languages():
+    supported = TreeSitterSymbolExtractor.list_supported_languages()
+    assert "toml" in supported
+    assert ".toml" in supported["toml"]

--- a/tests/test_tree_sitter_languages.py
+++ b/tests/test_tree_sitter_languages.py
@@ -12,6 +12,7 @@ LANG_SAMPLES = {
     "c": b"int foo() { return 42; }\n",
     "dart": b"int foo() { return 42; }\n",
     "zig": b"pub fn foo() void { }\n",
+    "toml": b'[package]\nname = "test"\n',
 }
 
 


### PR DESCRIPTION
## Summary

- Add tree-sitter queries and language mapping for TOML (`.toml`)
- Captures table headers (bare, dotted, quoted) and array table headers
- Quoted table names are normalized (wrapping quotes stripped via `_strip_wrapping_quotes` helper)

## Testing

```
pytest tests/test_toml_symbols.py tests/test_tree_sitter_languages.py tests/test_symbol_extraction_multilang.py -v
```